### PR TITLE
feat: 관리자 발행/제보 API 정합성 및 사용자 기사 이미지 렌더링 개선

### DIFF
--- a/qroad/.env.example
+++ b/qroad/.env.example
@@ -1,6 +1,6 @@
 # Development (로컬 개발 시)
 # Vite 프록시를 사용하므로 상대 경로 사용
-VITE_API_BASE_URL=
+VITE_API_BASE_URL=http://localhost:8080
 
 # Production (Vercel 배포 시)
 # Vercel 환경 변수에서 설정:

--- a/qroad/src/api/admin/publications.ts
+++ b/qroad/src/api/admin/publications.ts
@@ -5,23 +5,51 @@ import {
     PublicationDetailResponse,
     PublicationListResponse,
     PublicationProgressResponse,
+    PublicationUploadUrlRequest,
+    PublicationUploadUrlResponse,
 } from '@/types/admin';
 
 export const publicationsApi = {
     create: async (data: CreatePublicationRequest): Promise<CreatePublicationResponse> => {
-        // filePath가 null/undefined/빈 문자열이면 백엔드 not-null 제약 회피용 더미 경로를 사용한다.
-        const normalizedFilePath =
-            typeof data.filePath === 'string' && data.filePath.trim().length > 0
-                ? data.filePath
-                : 'temp/manual-upload.txt';
-
         const res = await apiClient.post('/api/admin/publications', {
             title: data.title,
-            content: data.content,
             publishedDate: data.publishedDate,
-            filePath: normalizedFilePath,
+            tempKey: data.tempKey,
         });
         return unwrapResponse(res) as CreatePublicationResponse;
+    },
+
+    requestUploadUrl: async (
+        data: PublicationUploadUrlRequest
+    ): Promise<PublicationUploadUrlResponse> => {
+        const res = await apiClient.post('/api/admin/publications/upload-url', data);
+        const body = unwrapResponse(res) as Record<string, unknown>;
+
+        const uploadUrl =
+            (body.uploadUrl as string | undefined) ??
+            (body.presignedUrl as string | undefined) ??
+            (body.url as string | undefined);
+        const tempKey = (body.tempKey as string | undefined) ?? (body.key as string | undefined);
+
+        if (!uploadUrl || !tempKey) {
+            throw new Error('업로드 URL 발급 응답 형식이 올바르지 않습니다.');
+        }
+
+        return { uploadUrl, tempKey };
+    },
+
+    uploadPdfToS3: async (uploadUrl: string, file: File): Promise<void> => {
+        const res = await fetch(uploadUrl, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': file.type || 'application/pdf',
+            },
+            body: file,
+        });
+
+        if (!res.ok) {
+            throw new Error(`PDF 업로드에 실패했습니다. (${res.status})`);
+        }
     },
 
     getProgress: async (jobId: string): Promise<PublicationProgressResponse> => {
@@ -51,3 +79,4 @@ export const publicationsApi = {
         return unwrapResponse(res);
     },
 };
+

--- a/qroad/src/api/admin/reports.ts
+++ b/qroad/src/api/admin/reports.ts
@@ -1,5 +1,34 @@
-import apiClient, { unwrapResponse } from '../client';
-import { GetReportsParams, ReportListResponse, ReportStatus } from '@/types/admin';
+﻿import apiClient, { unwrapResponse } from '../client';
+import { GetReportsParams, Report, ReportListResponse, ReportStatus } from '@/types/admin';
+
+const normalizeStatus = (status: unknown): ReportStatus => {
+    if (status === 'unconfirmed' || status === 'in_review' || status === 'completed') {
+        return status;
+    }
+
+    const normalized = String(status ?? '')
+        .trim()
+        .toUpperCase();
+
+    if (normalized === 'UNCONFIRMED' || normalized === 'PENDING') return 'unconfirmed';
+    if (normalized === 'IN_REVIEW' || normalized === 'REVIEWING') return 'in_review';
+    if (normalized === 'COMPLETED' || normalized === 'DONE') return 'completed';
+
+    return 'unconfirmed';
+};
+
+const normalizeReport = (item: Record<string, unknown>): Report => ({
+    report_id: Number(item.report_id ?? item.id ?? 0),
+    title: String(item.title ?? ''),
+    content: String(item.content ?? ''),
+    reporter_name: String(item.reporter_name ?? item.reporterName ?? item.reporterContact ?? ''),
+    reporter_region: String(item.reporter_region ?? item.reporterRegion ?? ''),
+    status: normalizeStatus(item.status),
+    created_at: String(item.created_at ?? item.createdAt ?? ''),
+    related_chunks: Array.isArray(item.related_chunks)
+        ? (item.related_chunks as Report['related_chunks'])
+        : [],
+});
 
 export const reportsApi = {
     getAll: async (params: GetReportsParams = {}): Promise<ReportListResponse> => {
@@ -11,15 +40,25 @@ export const reportsApi = {
         }
 
         const res = await apiClient.get('/api/admin/reports', { params: queryParams });
-        const body = unwrapResponse(res) as ReportListResponse | undefined;
-        return (
-            body ?? {
-                total_count: 0,
-                counts_by_status: { all: 0, unconfirmed: 0, in_review: 0, completed: 0 },
-                reports: [],
-            }
-        );
+        const body = unwrapResponse(res) as Record<string, unknown> | undefined;
+
+        const rawReports = Array.isArray(body?.reports) ? (body?.reports as Record<string, unknown>[]) : [];
+        const reports = rawReports.map(normalizeReport);
+
+        const totalCount = Number(body?.total_count ?? body?.totalCount ?? reports.length ?? 0);
+
+        return {
+            total_count: totalCount,
+            counts_by_status: {
+                all: totalCount,
+                unconfirmed: reports.filter((r) => r.status === 'unconfirmed').length,
+                in_review: reports.filter((r) => r.status === 'in_review').length,
+                completed: reports.filter((r) => r.status === 'completed').length,
+            },
+            reports,
+        };
     },
+
     updateStatus: async (reportId: number, status: ReportStatus) => {
         const res = await apiClient.patch(`/api/admin/reports/${reportId}`, { status });
         return unwrapResponse(res);

--- a/qroad/src/features/admin/pages/IssueCreate.tsx
+++ b/qroad/src/features/admin/pages/IssueCreate.tsx
@@ -20,7 +20,6 @@ export const IssueCreate = () => {
 
     const [issueNum, setIssueNum] = useState('');
     const [issueDate, setIssueDate] = useState('');
-    const [rawText, setRawText] = useState('');
     const [selectedFile, setSelectedFile] = useState<File | null>(null);
 
     const [jobId, setJobId] = useState<string | null>(null);
@@ -73,7 +72,16 @@ export const IssueCreate = () => {
             return;
         }
 
-        // 새 작업 시작 전에 이전 polling 상태를 초기화한다.
+        if (!selectedFile) {
+            toast.error('PDF 파일을 선택해주세요.');
+            return;
+        }
+
+        if (selectedFile.type && selectedFile.type !== 'application/pdf') {
+            toast.error('PDF 파일만 업로드할 수 있습니다.');
+            return;
+        }
+
         clearPolling();
         setError(null);
         setStatus('IDLE');
@@ -82,10 +90,21 @@ export const IssueCreate = () => {
         setJobId(null);
 
         try {
+            setMessage('PDF 업로드 URL을 요청 중입니다...');
+            const { uploadUrl, tempKey } = await publicationsApi.requestUploadUrl({
+                fileName: selectedFile.name,
+                contentType: selectedFile.type || 'application/pdf',
+                fileSize: selectedFile.size,
+            });
+
+            setMessage('PDF를 업로드하고 있습니다...');
+            await publicationsApi.uploadPdfToS3(uploadUrl, selectedFile);
+
+            setMessage('발행 작업 시작 요청 중입니다...');
             const response = await createMutation.mutateAsync({
                 title: issueNum,
-                content: rawText,
                 publishedDate: issueDate,
+                tempKey,
             });
 
             setJobId(response.jobId);
@@ -101,7 +120,7 @@ export const IssueCreate = () => {
             setError(errorMessage);
             setMessage(errorMessage);
         }
-    }, [clearPolling, createMutation, issueDate, issueNum, rawText, status]);
+    }, [clearPolling, createMutation, issueDate, issueNum, selectedFile, status]);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -150,7 +169,7 @@ export const IssueCreate = () => {
                 navigate(`/admin/issues/${paperId}`);
             } catch (err: unknown) {
                 if (axios.isAxiosError(err) && err.response?.status === 404) {
-                    const notFoundMessage = '작업이 만료되었거나 존재하지 않습니다';
+                    const notFoundMessage = '작업이 만료되었거나 존재하지 않습니다.';
                     stopWithFailure(notFoundMessage);
                     return;
                 }
@@ -163,7 +182,7 @@ export const IssueCreate = () => {
         const runPolling = () => {
             // 무한 polling을 막기 위해 10분을 초과하면 강제 종료한다.
             if (Date.now() - startTime >= POLLING_TIMEOUT_MS) {
-                stopWithFailure('작업 시간이 10분을 초과해 자동으로 중단되었습니다. 다시 시도해주세요.');
+                stopWithFailure('작업 시간이 10분을 초과하여 자동으로 중단되었습니다. 다시 시도해주세요.');
                 return;
             }
 
@@ -221,7 +240,7 @@ export const IssueCreate = () => {
                                     type="text"
                                     value={issueNum}
                                     onChange={(e) => setIssueNum(e.target.value)}
-                                    placeholder="예: 제123호 - 지역 소식"
+                                    placeholder="예: 제23호 - 지역 소식"
                                     className="w-full h-[48px] bg-[#FFFFFF] border border-[#D1D5DB] rounded-[8px] px-[16px] text-[#000000] placeholder-black/50 outline-none focus:border-[#2563EB]"
                                     required
                                 />
@@ -240,17 +259,6 @@ export const IssueCreate = () => {
                             </div>
                         </div>
 
-                        <div className="flex flex-col gap-[8px]">
-                            <label className="font-normal text-[14px] leading-[17px] tracking-[-0.5px] text-[#374151]">
-                                기사 원문
-                            </label>
-                            <textarea 
-                                value={rawText}
-                                onChange={(e) => setRawText(e.target.value)}
-                                className="w-full min-h-[300px] bg-[#FFFFFF] border border-[#D1D5DB] rounded-[8px] p-[16px] text-[#000000] placeholder-black/50 outline-none focus:border-[#2563EB] resize-y"
-                                required
-                            />
-                        </div>
                     </div>
 
                     {/* PDF Upload Box */}
@@ -259,7 +267,7 @@ export const IssueCreate = () => {
                             지면 PDF 업로드
                         </h3>
                         <p className="font-normal text-[12px] leading-[16px] tracking-[-0.5px] text-[#6B7280] mb-[16px]">
-                            통합 PDF 한 장으로 AI가 분석합니다
+                            통합 PDF 파일로 AI가 분석합니다.
                         </p>
 
                         <div className="w-full h-[282px] bg-[#F9FAFB] border-[2px] border-dashed border-[#D1D5DB] rounded-[8px] flex flex-col items-center justify-center relative">
@@ -295,7 +303,7 @@ export const IssueCreate = () => {
                             {status === 'FAILED' && error && <p className="text-sm text-red-600">{error}</p>}
                             {status === 'FAILED' && (
                                 <Button type="button" variant="outline" onClick={startPublicationJob} className="w-fit">
-                                    재시도
+                                    다시 시도
                                 </Button>
                             )}
                         </div>
@@ -337,4 +345,5 @@ export const IssueCreate = () => {
         </div>
     );
 };
+
 

--- a/qroad/src/features/admin/pages/ReportList.tsx
+++ b/qroad/src/features/admin/pages/ReportList.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect } from 'react';
+﻿import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ChevronLeft } from 'lucide-react';
 import { reportsApi } from '@/api/admin/reports';
-import { Report, ReportStatus, ReportListResponse } from '@/types/admin';
+import { Report, ReportListResponse } from '@/types/admin';
 
 export const ReportList = () => {
     const navigate = useNavigate();
@@ -12,7 +12,6 @@ export const ReportList = () => {
     useEffect(() => {
         const fetchReports = async () => {
             try {
-                // Fetch reports (mock or actual DB fetch)
                 const res: ReportListResponse = await reportsApi.getAll({ page: 1, limit: 10 });
                 setReports(res.reports);
             } catch (error) {
@@ -21,111 +20,70 @@ export const ReportList = () => {
                 setIsLoading(false);
             }
         };
-        fetchReports();
+
+        void fetchReports();
     }, []);
-
-    const formatStatus = (status: ReportStatus) => {
-        switch (status) {
-            case 'unconfirmed':
-                return <span className="text-[#991B1B]">미확인</span>;
-            case 'completed':
-                return <span className="text-[#166534]">확인 완료</span>;
-            case 'in_review':
-                return <span className="text-[#854D0E]">검토 중</span>;
-            default:
-                return null;
-        }
-    };
-
-    // To display a mock topic or extract from tags if present
-    const getMockTopic = (id: number) => {
-        const topics = ['교통', '시설', '문화', '안전', '환경'];
-        return topics[id % topics.length] || '기타';
-    };
 
     return (
         <div className="w-full min-h-full font-['Inter'] relative bg-[#F9FAFB] pl-[48px] pt-[48px]">
-            {/* Header / Breadcrumbs */}
             <div className="w-[1544px] mb-[36px]">
-                {/* Back Button Area */}
-                <div 
-                    className="flex items-center gap-[8px] cursor-pointer w-fit mb-[16px]"
-                    onClick={() => navigate(-1)}
-                >
+                <div className="flex items-center gap-[8px] cursor-pointer w-fit mb-[16px]" onClick={() => navigate(-1)}>
                     <ChevronLeft className="w-[12px] h-[14px] text-[#2563EB]" />
                     <span className="font-normal text-[14px] leading-[17px] tracking-[-0.5px] text-[#2563EB]">
                         이전으로 돌아가기
                     </span>
                 </div>
-                {/* Title */}
+
                 <h2 className="font-normal text-[36px] leading-[44px] tracking-[-0.5px] text-[#111827] mb-[8px]">
                     제보 확인
                 </h2>
                 <p className="font-normal text-[16px] leading-[20px] tracking-[-0.5px] text-[#4B5563]">
-                    사용자가 제출한 제보 내용을 확인할 수 있습니다
+                    사용자가 제출한 제보 내용을 확인할 수 있습니다.
                 </p>
             </div>
 
-            {/* List Box Container */}
             <div className="w-[1544px] bg-[#FFFFFF] border border-[#E5E7EB] rounded-[8px] overflow-hidden">
-                {/* Box Title */}
                 <div className="w-full h-[62px] border-b border-[#E5E7EB] px-[24px] flex items-center">
-                    <h3 className="font-medium text-[18px] leading-[22px] tracking-[-0.5px] text-[#111827]">
-                        제보 목록
-                    </h3>
+                    <h3 className="font-medium text-[18px] leading-[22px] tracking-[-0.5px] text-[#111827]">제보 목록</h3>
                 </div>
 
-                {/* Table Header */}
-                <div className="w-full h-[45px] bg-[#F9FAFB] border-b border-[#E5E7EB] grid grid-cols-6 items-center px-[24px]">
-                    <div className="font-medium text-[14px] leading-[17px] tracking-[-0.5px] text-[#374151]">상태</div>
+                <div className="w-full h-[45px] bg-[#F9FAFB] border-b border-[#E5E7EB] grid grid-cols-5 items-center px-[24px]">
                     <div className="font-medium text-[14px] leading-[17px] tracking-[-0.5px] text-[#374151]">제목</div>
-                    <div className="font-medium text-[14px] leading-[17px] tracking-[-0.5px] text-[#374151]">내용 요약</div>
-                    <div className="font-medium text-[14px] leading-[17px] tracking-[-0.5px] text-[#374151]">주제</div>
+                    <div className="font-medium text-[14px] leading-[17px] tracking-[-0.5px] text-[#374151]">본문</div>
+                    <div className="font-medium text-[14px] leading-[17px] tracking-[-0.5px] text-[#374151]">제보자 연락처</div>
                     <div className="font-medium text-[14px] leading-[17px] tracking-[-0.5px] text-[#374151]">접수일</div>
                     <div className="font-medium text-[14px] leading-[17px] tracking-[-0.5px] text-[#374151]">상세보기</div>
                 </div>
 
-                {/* Table List Items */}
                 <div className="w-full flex flex-col min-h-[300px]">
                     {isLoading ? (
-                        <div className="w-full py-20 flex justify-center items-center text-[#6B7280]">
-                            로딩 중...
-                        </div>
+                        <div className="w-full py-20 flex justify-center items-center text-[#6B7280]">로딩 중...</div>
                     ) : reports.length === 0 ? (
                         <div className="w-full py-20 flex justify-center items-center text-[#6B7280]">
                             제보 내역이 없습니다.
                         </div>
                     ) : (
                         reports.map((report) => (
-                            <div 
-                                key={report.report_id} 
-                                className="w-full min-h-[73px] py-[16px] border-b border-[#F3F4F6] grid grid-cols-6 items-center px-[24px]"
+                            <div
+                                key={report.report_id}
+                                className="w-full min-h-[73px] py-[16px] border-b border-[#F3F4F6] grid grid-cols-5 items-center px-[24px]"
                             >
-                                {/* Status */}
-                                <div className="font-medium text-[12px] leading-[16px] tracking-[-0.5px]">
-                                    {formatStatus(report.status)}
-                                </div>
-                                {/* Title */}
                                 <div className="font-normal text-[14px] leading-[17px] tracking-[-0.5px] text-[#111827] truncate pr-4">
                                     {report.title}
                                 </div>
-                                {/* Summary */}
                                 <div className="flex flex-col pr-4">
                                     <p className="font-normal text-[14px] leading-[17px] tracking-[-0.5px] text-[#4B5563] truncate">
                                         {report.content}
                                     </p>
                                 </div>
-                                {/* Topic (Mocked) */}
-                                <div className="font-normal text-[14px] leading-[17px] tracking-[-0.5px] text-[#4B5563]">
-                                    {getMockTopic(report.report_id)}
+                                <div className="font-normal text-[14px] leading-[17px] tracking-[-0.5px] text-[#4B5563] truncate pr-4">
+                                    {report.reporter_name || '-'}
                                 </div>
-                                {/* Date */}
                                 <div className="font-normal text-[14px] leading-[17px] tracking-[-0.5px] text-[#4B5563]">
-                                    {report.created_at.split('T')[0]}
+                                    {report.created_at ? report.created_at.split('T')[0] : '-'}
                                 </div>
-                                {/* Detail Button */}
                                 <div>
-                                    <button 
+                                    <button
                                         className="w-[80px] h-[28px] bg-[#2563EB] hover:bg-[#1D4ED8] text-[#FFFFFF] font-normal text-[14px] leading-[17px] tracking-[-0.5px] rounded-[4px] flex items-center justify-center transition-colors"
                                         onClick={() => {
                                             alert(`"${report.title}" 제보 상세 정보를 확인합니다.`);

--- a/qroad/src/features/user/pages/ArticleDetailPage.tsx
+++ b/qroad/src/features/user/pages/ArticleDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { 
-  ArrowLeft, Share2, MoreVertical, Sparkles, Check, Building, User,
+  ArrowLeft, Sparkles, Check, Building, User,
   Landmark, Home, Coins, ThumbsUp, Heart, Frown, Angry, MessageSquareWarning 
 } from "lucide-react";
 import { ArticleDetailResponse, EmotionType } from '@/types/admin';
@@ -52,14 +52,7 @@ export function ArticleDetail({ article, onBack }: ArticleDetailProps) {
 					<button onClick={onBack} className="w-10 h-10 flex items-center justify-center -ml-2">
 						<ArrowLeft className="w-6 h-6 text-[#374151]" />
 					</button>
-					<div className="flex items-center">
-						<button className="w-10 h-10 flex items-center justify-center">
-							<Share2 className="w-5 h-5 text-[#374151]" />
-						</button>
-						<button className="w-8 h-10 flex items-center justify-center -mr-2">
-							<MoreVertical className="w-5 h-5 text-[#374151]" />
-						</button>
-					</div>
+					<div className="w-10 h-10" />
 				</header>
 
 				<main className="w-full">
@@ -101,7 +94,7 @@ export function ArticleDetail({ article, onBack }: ArticleDetailProps) {
 							</p>
 							
 							{/* Key Points - If no structured AI points, mock them based on user provided data */}
-							<div className="flex flex-col gap-2">
+							<div className="hidden">
 								<h3 className="text-[14px] font-normal text-[#111827] tracking-[-0.5px] mb-1">핵심 내용</h3>
 								<div className="flex items-start gap-2">
 									<Check className="w-3 h-3 text-[#2563EB] mt-1 shrink-0" strokeWidth={3} />

--- a/qroad/src/features/user/pages/ArticleDetailPage.tsx
+++ b/qroad/src/features/user/pages/ArticleDetailPage.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import { 
-  ArrowLeft, Sparkles, Check, Building, User,
+  ArrowLeft, Sparkles, Check, Building, User, ImageOff,
   Landmark, Home, Coins, ThumbsUp, Heart, Frown, Angry, MessageSquareWarning 
 } from "lucide-react";
 import { ArticleDetailResponse, EmotionType } from '@/types/admin';
 import { userApi } from '@/api/user';
+import { toRenderableImageUrl } from '@/shared/utils/image';
 
 interface ArticleDetailProps {
 	article: ArticleDetailResponse;
@@ -210,7 +211,19 @@ export function ArticleDetail({ article, onBack }: ArticleDetailProps) {
 							<div className="flex flex-col gap-3">
 								{article.articleRelatedDTOS.map((related) => (
 									<div key={related.id} onClick={() => window.open(related.link, '_blank')} className="w-full p-[13px] bg-white border border-[#E5E7EB] rounded-[12px] flex gap-[12px] cursor-pointer active:scale-[0.98] transition-transform">
-										<div className="w-[80px] h-[80px] rounded-[8px] bg-[#E5E7EB] shrink-0 overflow-hidden relative" />
+										{toRenderableImageUrl(related.imagePath) ? (
+											<img
+												src={toRenderableImageUrl(related.imagePath)!}
+												alt={related.title}
+												className="w-[80px] h-[80px] rounded-[8px] object-cover shrink-0"
+												loading="lazy"
+											/>
+										) : (
+											<div className="w-[80px] h-[80px] rounded-[8px] bg-[#F3F4F6] shrink-0 overflow-hidden flex flex-col items-center justify-center text-[#9CA3AF]">
+												<ImageOff className="w-4 h-4 mb-1" />
+												<span className="text-[10px] tracking-[-0.5px]">이미지 없음</span>
+											</div>
+										)}
 										<div className="flex flex-col justify-center flex-1">
 											<h3 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] mb-1 line-clamp-2">
 												{related.title}

--- a/qroad/src/features/user/pages/ArticleDetailPageWrapper.tsx
+++ b/qroad/src/features/user/pages/ArticleDetailPageWrapper.tsx
@@ -4,41 +4,37 @@ import { useArticleDetail } from '@/hooks/user/useLandingPage';
 import { Loader2 } from 'lucide-react';
 
 export function ArticleDetailWrapper() {
-	const navigate = useNavigate();
-	const { articleId } = useParams();
-	const { data: article, isLoading, error } = useArticleDetail(Number(articleId));
+  const navigate = useNavigate();
+  const { articleId } = useParams();
+  const { data: article, isLoading, error } = useArticleDetail(Number(articleId));
 
-	if (isLoading) {
-		return (
-			<div className="min-h-screen bg-gradient-to-br from-violet-50 via-purple-50 to-fuchsia-50 flex items-center justify-center">
-				<div className="text-center">
-					<Loader2 className="w-16 h-16 text-purple-600 animate-spin mx-auto mb-4" />
-					<p className="text-gray-600">기사를 불러오는 중...</p>
-				</div>
-			</div>
-		);
-	}
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-[#F9FAFB] flex items-center justify-center p-4">
+        <div className="text-center">
+          <Loader2 className="w-16 h-16 text-[#2563EB] animate-spin mx-auto mb-4" />
+          <p className="text-[#4B5563] text-[14px]">기사를 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
 
-	if (error || !article) {
-		return (
-			<div className="min-h-screen bg-gradient-to-br from-violet-50 via-purple-50 to-fuchsia-50 flex items-center justify-center px-6">
-				<div className="text-center space-y-4">
-					<p className="text-foreground/80 text-lg font-semibold">기사를 찾을 수 없습니다.</p>
-					<button
-						onClick={() => navigate(-1)}
-						className="px-6 py-2 rounded-full bg-violet-600 text-white text-sm font-semibold"
-					>
-						뒤로가기
-					</button>
-				</div>
-			</div>
-		);
-	}
+  if (error || !article) {
+    return (
+      <div className="min-h-screen bg-[#F9FAFB] flex items-center justify-center p-4">
+        <div className="w-full max-w-[375px] bg-white rounded-2xl p-6 shadow-sm border border-[#E5E7EB] text-center">
+          <p className="text-[#111827] font-medium mb-2">기사를 찾을 수 없습니다.</p>
+          <p className="text-[14px] text-[#B91C1C] mb-4">{String(error ?? '')}</p>
+          <button
+            onClick={() => navigate(-1)}
+            className="px-6 py-2 rounded-full bg-[#2563EB] text-white text-sm font-semibold"
+          >
+            뒤로가기
+          </button>
+        </div>
+      </div>
+    );
+  }
 
-	return (
-		<ArticleDetail
-			article={article}
-			onBack={() => navigate(-1)}
-		/>
-	);
+  return <ArticleDetail article={article} onBack={() => navigate(-1)} />;
 }

--- a/qroad/src/features/user/pages/qrlandingPage.tsx
+++ b/qroad/src/features/user/pages/qrlandingPage.tsx
@@ -1,199 +1,174 @@
-import { Loader2 } from "lucide-react";
+﻿import { Loader2 } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useUserLandingPage } from '@/hooks/user/useLandingPage';
 
 interface ArticleListProps {
-	onArticleClick: (id: number) => void;
-	articles: Array<{ id: number; title: string }>;
-	isLoading?: boolean;
+  onArticleClick: (id: number) => void;
+  articles: Array<{ id: number; title: string }>;
+  isLoading?: boolean;
+  publishedDate?: string;
 }
 
-export function ArticleList({ onArticleClick, articles, isLoading }: ArticleListProps) {
-	const navigate = useNavigate();
-	if (isLoading) {
-		return (
-			<div className="min-h-screen bg-[#F9FAFB] flex items-center justify-center">
-				<div className="text-center">
-					<Loader2 className="w-16 h-16 text-[#2563EB] animate-spin mx-auto mb-4" />
-					<p className="text-[#4B5563] text-[14px]">기사를 불러오는 중...</p>
-				</div>
-			</div>
-		);
-	}
+export function ArticleList({ onArticleClick, articles, isLoading, publishedDate }: ArticleListProps) {
+  const navigate = useNavigate();
 
-	// API 데이터가 부족할 경우를 대비해 사용자가 요청한 디자인의 mock 데이터를 합성합니다.
-	const mainArticle = articles[0] ? {
-		...articles[0],
-		category: "속보",
-		categoryColor: "text-[#B91C1C]",
-		time: "15분 전",
-		title: articles[0].title || "시청, 2024년 예산안 최종 확정... 복지·교육분 야 대폭 증액",
-		summary: "경기도 시청이 내년도 예산안을 최종 확정하며 복지와 교육 분야에 전년 대비 20% 증액된 예산을 배정했다. 특히 저소득층 지원과 공교육 강화에 집중 투자할 계획 이다."
-	} : {
-		id: 1,
-		category: "속보",
-		categoryColor: "text-[#B91C1C]",
-		time: "15분 전",
-		title: "시청, 2024년 예산안 최종 확정... 복지·교육분 야 대폭 증액",
-		summary: "경기도 시청이 내년도 예산안을 최종 확정하며 복지와 교육 분야에 전년 대비 20% 증액된 예산을 배정했다. 특히 저소득층 지원과 공교육 강화에 집중 투자할 계획 이다."
-	};
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-[#F9FAFB] flex items-center justify-center">
+        <div className="text-center">
+          <Loader2 className="w-16 h-16 text-[#2563EB] animate-spin mx-auto mb-4" />
+          <p className="text-[#4B5563] text-[14px]">기사를 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
 
-	const categories = [
-		{ label: "교육", color: "text-[#1D4ED8]", time: "2시간 전", mockTitle: "관내 초등학교 3곳, 스마트 교실 시범 운영" },
-		{ label: "교통", color: "text-[#7E22CE]", time: "3시간 전", mockTitle: "지하철 2호선 연장 공사, 예정보다 빠르게 진행" },
-		{ label: "경제", color: "text-[#A16207]", time: "4시간 전", mockTitle: "전통시장 활성화 프로젝트, 소상공인 호응 높아" },
-		{ label: "복지", color: "text-[#BE185D]", time: "5시간 전", mockTitle: "노인복지센터 신규 프로그램 접수 시작" },
-		{ label: "스포츠", color: "text-[#4338CA]", time: "6시간 전", mockTitle: "시민 체육대회 참가 신청 접수 중" },
-	];
+  const mainArticle = articles[0] ?? null;
+  const subArticles = articles.slice(1);
+  const publishedDateLabel = publishedDate || '-';
 
-	const subArticles = articles.length > 1
-		? articles.slice(1).map((a, i) => {
-			const cat = categories[i % categories.length];
-			return {
-				id: a.id,
-				title: a.title,
-				category: cat.label,
-				categoryColor: cat.color,
-				time: cat.time
-			};
-		})
-		: categories.map((cat, index) => ({
-			id: index + 2,
-			title: cat.mockTitle,
-			category: cat.label,
-			categoryColor: cat.color,
-			time: cat.time
-		}));
+  return (
+    <div className="w-full min-h-screen bg-[#F9FAFB] flex flex-col items-center">
+      <div className="w-full max-w-[375px] bg-[#F9FAFB] relative min-h-screen pb-[120px] shadow-sm">
+        <header className="w-full h-[57px] bg-white border-b border-[#E5E7EB] flex items-center justify-between px-4 sticky top-0 z-50">
+          <div className="flex items-center gap-2">
+            <img src="/qr.svg" alt="QRoad Logo" className="w-[16px] h-[16px]" />
+            <span className="text-[20px] font-bold text-[#111827] tracking-[-0.5px]">QRoad</span>
+          </div>
+          <a
+            href="https://curly-marjoram-9d4.notion.site/2bbe6f94cb6d806281d6cfe611061601"
+            target="_blank"
+            rel="noreferrer"
+            className="bg-[#F3F4F6] rounded-full px-3 py-[6px] flex items-center justify-center hover:bg-gray-200 transition-colors"
+          >
+            <span className="text-[12px] text-[#374151] tracking-[-0.5px]">신문 구독방법</span>
+          </a>
+        </header>
 
-	return (
-		<div className="w-full min-h-screen bg-[#F9FAFB] flex flex-col items-center">
-			{/* Mobile Wrapper */}
-			<div className="w-full max-w-[375px] bg-[#F9FAFB] relative min-h-screen pb-[120px] shadow-sm">
+        <div className="w-full px-4 py-[16px] bg-gradient-to-r from-[#EFF6FF] to-[#EEF2FF] border-b border-[#DBEAFE] flex flex-col justify-center">
+          <div className="flex flex-col gap-[2px] mb-[20px]">
+            <h2 className="text-[16px] font-normal text-[#111827] tracking-[-0.5px]">오늘의 주간 소식</h2>
+            <p className="text-[12px] font-normal text-[#4B5563] tracking-[-0.5px]">발행일: {publishedDateLabel}</p>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <img src="/robot.svg" alt="AI News" className="w-3.5 h-3.5" />
+            <span className="text-[14px] font-normal text-[#374151] tracking-[-0.5px]">AI가 선별한 오늘의 핵심 뉴스</span>
+          </div>
+        </div>
 
-				{/* Top Navigation */}
-				<header className="w-full h-[57px] bg-white border-b border-[#E5E7EB] flex items-center justify-between px-4 sticky top-0 z-50">
-					<div className="flex items-center gap-2">
-						<img src="/qr.svg" alt="QRoad Logo" className="w-[16px] h-[16px]" />
-						<span className="text-[20px] font-bold text-[#111827] tracking-[-0.5px]">QRoad</span>
-					</div>
-					<a href="https://curly-marjoram-9d4.notion.site/2bbe6f94cb6d806281d6cfe611061601" target="_blank" rel="noreferrer" className="bg-[#F3F4F6] rounded-full px-3 py-[6px] flex items-center justify-center hover:bg-gray-200 transition-colors">
-						<span className="text-[12px] text-[#374151] tracking-[-0.5px]">신문 구독방법</span>
-					</a>
-				</header>
+        <main className="w-full px-4 pt-4">
+          <div className="mb-10">
+            <div className="flex items-center gap-1.5 mb-3">
+              <img src="/star.svg" alt="Hot News" className="w-[18px] h-[18px]" />
+              <h3 className="text-[18px] font-normal text-[#111827] tracking-[-0.5px]">이번 주 주요 뉴스</h3>
+            </div>
 
-				{/* Intro Banner */}
-				<div className="w-full px-4 py-[16px] bg-gradient-to-r from-[#EFF6FF] to-[#EEF2FF] border-b border-[#DBEAFE] flex flex-col justify-center">
-					<div className="flex flex-col gap-[2px] mb-[20px]">
-						<h2 className="text-[16px] font-normal text-[#111827] tracking-[-0.5px]">2024년 3월 12일 화요일 주간</h2>
-						<p className="text-[12px] font-normal text-[#4B5563] tracking-[-0.5px]">경기일보 · QR 스캔으로 빠르게 접속</p>
-					</div>
-					<div className="flex items-center gap-1.5">
-						<img src="/robot.svg" alt="AI News" className="w-3.5 h-3.5" />
-						<span className="text-[14px] font-normal text-[#374151] tracking-[-0.5px]">AI가 선별한 오늘의 핵심 뉴스</span>
-					</div>
-				</div>
+            {mainArticle ? (
+              <div
+                onClick={() => onArticleClick(mainArticle.id)}
+                className="w-full bg-white border border-[#E5E7EB] shadow-[0px_1px_2px_rgba(0,0,0,0.05)] rounded-[12px] overflow-hidden cursor-pointer active:scale-[0.98] transition-transform"
+              >
+                <div className="w-full aspect-[341/192] bg-[#F3F4F6] relative" />
+                <div className="p-4">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="text-[12px] font-normal text-[#B91C1C] tracking-[-0.5px]">주요뉴스</span>
+                    <span className="text-[12px] font-normal text-[#6B7280] tracking-[-0.5px]">{publishedDateLabel}</span>
+                  </div>
+                  <h4 className="text-[16px] font-normal text-[#111827] leading-[24px] tracking-[-0.5px] line-clamp-2">
+                    {mainArticle.title}
+                  </h4>
+                </div>
+              </div>
+            ) : (
+              <div className="w-full p-4 bg-white border border-[#E5E7EB] rounded-[12px] text-[14px] text-[#6B7280]">
+                기사 데이터가 없습니다.
+              </div>
+            )}
+          </div>
 
-				<main className="w-full px-4 pt-4">
-					{/* Featured Article */}
-					<div className="mb-10">
-						<div className="flex items-center gap-1.5 mb-3">
-							<img src="/star.svg" alt="Hot News" className="w-[18px] h-[18px]" />
-							<h3 className="text-[18px] font-normal text-[#111827] tracking-[-0.5px]">이번 호 주요 뉴스</h3>
-						</div>
+          <div>
+            <div className="flex items-center gap-1.5 mb-3">
+              <img src="/list.svg" alt="Article List" className="w-4 h-4" />
+              <h3 className="text-[16px] font-normal text-[#111827] tracking-[-0.5px]">이번 주 기사</h3>
+            </div>
 
-						<div
-							onClick={() => onArticleClick(mainArticle.id)}
-							className="w-full bg-white border border-[#E5E7EB] shadow-[0px_1px_2px_rgba(0,0,0,0.05)] rounded-[12px] overflow-hidden cursor-pointer active:scale-[0.98] transition-transform"
-						>
-							{/* Placeholder for Image (341x192) */}
-							<div className="w-full aspect-[341/192] bg-[#F3F4F6] relative">
-							</div>
+            <div className="flex flex-col gap-3">
+              {subArticles.length > 0 ? (
+                subArticles.map((article) => (
+                  <div
+                    key={article.id}
+                    onClick={() => onArticleClick(article.id)}
+                    className="w-full h-[106px] bg-white border border-[#E5E7EB] shadow-[0px_1px_2px_rgba(0,0,0,0.05)] rounded-[12px] p-[13px] flex gap-[12px] cursor-pointer active:scale-[0.98] transition-transform"
+                  >
+                    <div className="w-[80px] h-[80px] rounded-[8px] bg-[#F3F4F6] shrink-0 overflow-hidden relative" />
+                    <div className="flex flex-col flex-1 justify-center">
+                      <div className="flex items-center gap-2 mb-1.5">
+                        <span className="text-[12px] font-normal text-[#2563EB] tracking-[-0.5px]">뉴스</span>
+                        <span className="text-[12px] font-normal text-[#6B7280] tracking-[-0.5px]">{publishedDateLabel}</span>
+                      </div>
+                      <h4 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] line-clamp-2">
+                        {article.title}
+                      </h4>
+                    </div>
+                  </div>
+                ))
+              ) : (
+                <div className="w-full p-4 bg-white border border-[#E5E7EB] rounded-[12px] text-[14px] text-[#6B7280]">
+                  추가 기사 데이터가 없습니다.
+                </div>
+              )}
+            </div>
+          </div>
+        </main>
 
-							<div className="p-4">
-								<div className="flex items-center gap-2 mb-2">
-									<span className={`text-[12px] font-normal ${mainArticle.categoryColor} tracking-[-0.5px]`}>{mainArticle.category}</span>
-									<span className="text-[12px] font-normal text-[#6B7280] tracking-[-0.5px]">{mainArticle.time}</span>
-								</div>
-								<h4 className="text-[16px] font-normal text-[#111827] leading-[24px] tracking-[-0.5px] mb-2 line-clamp-2">
-									{mainArticle.title}
-								</h4>
-								<p className="text-[14px] font-normal text-[#4B5563] leading-[20px] tracking-[-0.5px] line-clamp-3">
-									{mainArticle.summary}
-								</p>
-							</div>
-						</div>
-					</div>
-
-					{/* Article List */}
-					<div>
-						<div className="flex items-center gap-1.5 mb-3">
-							<img src="/list.svg" alt="Article List" className="w-4 h-4" />
-							<h3 className="text-[16px] font-normal text-[#111827] tracking-[-0.5px]">이번 호 기사</h3>
-						</div>
-
-						<div className="flex flex-col gap-3">
-							{subArticles.map((article) => (
-								<div
-									key={article.id}
-									onClick={() => onArticleClick(article.id)}
-									className="w-full h-[106px] bg-white border border-[#E5E7EB] shadow-[0px_1px_2px_rgba(0,0,0,0.05)] rounded-[12px] p-[13px] flex gap-[12px] cursor-pointer active:scale-[0.98] transition-transform"
-								>
-									<div className="w-[80px] h-[80px] rounded-[8px] bg-[#F3F4F6] shrink-0 overflow-hidden relative">
-									</div>
-									<div className="flex flex-col flex-1 justify-center">
-										<div className="flex items-center gap-2 mb-1.5">
-											<span className={`text-[12px] font-normal ${article.categoryColor} tracking-[-0.5px]`}>{article.category}</span>
-											<span className="text-[12px] font-normal text-[#6B7280] tracking-[-0.5px]">{article.time}</span>
-										</div>
-										<h4 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] line-clamp-2">
-											{article.title}
-										</h4>
-									</div>
-								</div>
-							))}
-						</div>
-					</div>
-				</main>
-
-				{/* Fixed Footer */}
-				<div className="fixed bottom-0 left-0 right-0 w-full bg-white flex flex-col items-center justify-center pt-3 pb-8 z-40 border-t border-[#E5E7EB]">
-					<div className="w-full max-w-[375px] px-4 flex flex-col gap-[10px]">
-						<button onClick={() => navigate('/report')} className="w-full h-[52px] bg-gradient-to-r from-[#2563EB] to-[#4F46E5] shadow-[0px_4px_6px_rgba(0,0,0,0.1),0px_10px_15px_rgba(0,0,0,0.1)] rounded-[12px] flex items-center justify-center gap-2 active:scale-[0.98] transition-transform">
-							<img src="/white_docu.svg" alt="Report" className="w-4 h-4 brightness-0 invert" />
-							<span className="text-[16px] font-normal text-white text-center tracking-[-0.5px]">민원 및 제보</span>
-						</button>
-						<p className="text-[12px] font-normal text-[#6B7280] text-center tracking-[-0.5px]">지역 신문을 더 편리하게 만나보세요</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	);
+        <div className="fixed bottom-0 left-0 right-0 w-full bg-white flex flex-col items-center justify-center pt-3 pb-8 z-40 border-t border-[#E5E7EB]">
+          <div className="w-full max-w-[375px] px-4 flex flex-col gap-[10px]">
+            <button
+              onClick={() => navigate('/report')}
+              className="w-full h-[52px] bg-gradient-to-r from-[#2563EB] to-[#4F46E5] shadow-[0px_4px_6px_rgba(0,0,0,0.1),0px_10px_15px_rgba(0,0,0,0.1)] rounded-[12px] flex items-center justify-center gap-2 active:scale-[0.98] transition-transform"
+            >
+              <img src="/white_docu.svg" alt="Report" className="w-4 h-4 brightness-0 invert" />
+              <span className="text-[16px] font-normal text-white text-center tracking-[-0.5px]">민원 및 제보</span>
+            </button>
+            <p className="text-[12px] font-normal text-[#6B7280] text-center tracking-[-0.5px]">지역 소식을 편리하게 만나보세요.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export function QRLandingPage() {
-	const navigate = useNavigate();
-	const { paperId } = useParams<{ paperId: string }>();
-	const { data, isLoading, error } = useUserLandingPage(Number(paperId));
+  const navigate = useNavigate();
+  const { paperId } = useParams<{ paperId: string }>();
+  const { data, isLoading, error } = useUserLandingPage(Number(paperId));
 
-	const handleArticleClick = (id: number) => {
-		navigate(`/article/${id}`);
-	};
+  const handleArticleClick = (id: number) => {
+    navigate(`/article/${id}`);
+  };
 
-	if (error) {
-		return (
-			<div className="min-h-screen bg-[#F9FAFB] flex flex-col items-center justify-center p-4">
-				<div className="w-full max-w-[375px] bg-white rounded-2xl p-6 shadow-sm border border-[#E5E7EB] text-center">
-					<p className="text-[#111827] font-medium mb-2">기사를 불러올 수 없습니다</p>
-					<p className="text-[14px] text-[#B91C1C]">{String(error)}</p>
-				</div>
-			</div>
-		);
-	}
+  if (error) {
+    return (
+      <div className="min-h-screen bg-[#F9FAFB] flex flex-col items-center justify-center p-4">
+        <div className="w-full max-w-[375px] bg-white rounded-2xl p-6 shadow-sm border border-[#E5E7EB] text-center">
+          <p className="text-[#111827] font-medium mb-2">기사를 불러올 수 없습니다.</p>
+          <p className="text-[14px] text-[#B91C1C]">{String(error)}</p>
+        </div>
+      </div>
+    );
+  }
 
-	const articles = (data?.articleSimpleDTOS || []).map(article => ({
-		id: article.id,
-		title: article.title,
-	}));
+  const articles = (data?.articleSimpleDTOS || []).map((article) => ({
+    id: article.id,
+    title: article.title,
+  }));
 
-	return <ArticleList onArticleClick={handleArticleClick} articles={articles} isLoading={isLoading} />;
+  return (
+    <ArticleList
+      onArticleClick={handleArticleClick}
+      articles={articles}
+      isLoading={isLoading}
+      publishedDate={data?.publishedDate}
+    />
+  );
 }

--- a/qroad/src/features/user/pages/qrlandingPage.tsx
+++ b/qroad/src/features/user/pages/qrlandingPage.tsx
@@ -1,10 +1,11 @@
-﻿import { Loader2 } from 'lucide-react';
+import { ImageOff, Loader2 } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useUserLandingPage } from '@/hooks/user/useLandingPage';
+import { toRenderableImageUrl } from '@/shared/utils/image';
 
 interface ArticleListProps {
   onArticleClick: (id: number) => void;
-  articles: Array<{ id: number; title: string }>;
+  articles: Array<{ id: number; title: string; imagePath?: string }>;
   isLoading?: boolean;
   publishedDate?: string;
 }
@@ -26,6 +27,12 @@ export function ArticleList({ onArticleClick, articles, isLoading, publishedDate
   const mainArticle = articles[0] ?? null;
   const subArticles = articles.slice(1);
   const publishedDateLabel = publishedDate || '-';
+  const Placeholder = () => (
+    <div className="w-full h-full bg-[#F3F4F6] flex flex-col items-center justify-center text-[#9CA3AF]">
+      <ImageOff className="w-5 h-5 mb-1" />
+      <span className="text-[11px] tracking-[-0.5px]">이미지 없음</span>
+    </div>
+  );
 
   return (
     <div className="w-full min-h-screen bg-[#F9FAFB] flex flex-col items-center">
@@ -68,7 +75,16 @@ export function ArticleList({ onArticleClick, articles, isLoading, publishedDate
                 onClick={() => onArticleClick(mainArticle.id)}
                 className="w-full bg-white border border-[#E5E7EB] shadow-[0px_1px_2px_rgba(0,0,0,0.05)] rounded-[12px] overflow-hidden cursor-pointer active:scale-[0.98] transition-transform"
               >
-                <div className="w-full aspect-[341/192] bg-[#F3F4F6] relative" />
+                {toRenderableImageUrl(mainArticle.imagePath) ? (
+                  <img
+                    src={toRenderableImageUrl(mainArticle.imagePath)!}
+                    alt={mainArticle.title}
+                    className="w-full aspect-[341/192] object-cover bg-[#F3F4F6]"
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="w-full aspect-[341/192]"><Placeholder /></div>
+                )}
                 <div className="p-4">
                   <div className="flex items-center gap-2 mb-2">
                     <span className="text-[12px] font-normal text-[#B91C1C] tracking-[-0.5px]">주요뉴스</span>
@@ -100,7 +116,16 @@ export function ArticleList({ onArticleClick, articles, isLoading, publishedDate
                     onClick={() => onArticleClick(article.id)}
                     className="w-full h-[106px] bg-white border border-[#E5E7EB] shadow-[0px_1px_2px_rgba(0,0,0,0.05)] rounded-[12px] p-[13px] flex gap-[12px] cursor-pointer active:scale-[0.98] transition-transform"
                   >
-                    <div className="w-[80px] h-[80px] rounded-[8px] bg-[#F3F4F6] shrink-0 overflow-hidden relative" />
+                    {toRenderableImageUrl(article.imagePath) ? (
+                      <img
+                        src={toRenderableImageUrl(article.imagePath)!}
+                        alt={article.title}
+                        className="w-[80px] h-[80px] rounded-[8px] object-cover shrink-0"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="w-[80px] h-[80px] rounded-[8px] shrink-0 overflow-hidden"><Placeholder /></div>
+                    )}
                     <div className="flex flex-col flex-1 justify-center">
                       <div className="flex items-center gap-2 mb-1.5">
                         <span className="text-[12px] font-normal text-[#2563EB] tracking-[-0.5px]">뉴스</span>
@@ -161,6 +186,7 @@ export function QRLandingPage() {
   const articles = (data?.articleSimpleDTOS || []).map((article) => ({
     id: article.id,
     title: article.title,
+    imagePath: article.imagePath,
   }));
 
   return (
@@ -172,3 +198,5 @@ export function QRLandingPage() {
     />
   );
 }
+
+

--- a/qroad/src/shared/utils/image.ts
+++ b/qroad/src/shared/utils/image.ts
@@ -1,0 +1,33 @@
+const PUBLIC_IMAGE_BASE_URL =
+    import.meta.env.VITE_S3_PUBLIC_BASE_URL ||
+    import.meta.env.VITE_IMAGE_BASE_URL ||
+    '';
+
+function trimSlashes(value: string): string {
+    return value.replace(/^\/+|\/+$/g, '');
+}
+
+/**
+ * imagePath is stored as an object key, so convert it to a renderable URL.
+ * - absolute URL: use as-is
+ * - object key: prepend configured public base URL
+ */
+export function toRenderableImageUrl(imagePath?: string | null): string | null {
+    if (!imagePath) return null;
+
+    const raw = imagePath.trim();
+    if (!raw) return null;
+
+    if (/^https?:\/\//i.test(raw)) {
+        return raw;
+    }
+
+    if (!PUBLIC_IMAGE_BASE_URL) {
+        return null;
+    }
+
+    const base = trimSlashes(PUBLIC_IMAGE_BASE_URL);
+    const key = trimSlashes(raw);
+    return `${base}/${key}`;
+}
+

--- a/qroad/src/types/admin.ts
+++ b/qroad/src/types/admin.ts
@@ -14,13 +14,23 @@ export interface ArticleInResponse {
 
 export interface CreatePublicationRequest {
     title: string;
-    content: string;
     publishedDate: string; // YYYY-MM-DD
-    filePath?: string | null;
+    tempKey: string;
 }
 
 export interface CreatePublicationResponse {
     jobId: string;
+}
+
+export interface PublicationUploadUrlRequest {
+    fileName: string;
+    contentType: string;
+    fileSize: number;
+}
+
+export interface PublicationUploadUrlResponse {
+    uploadUrl: string;
+    tempKey: string;
 }
 
 export type PublicationJobStatus = 'PROCESSING' | 'DONE' | 'FAILED';

--- a/qroad/src/types/admin.ts
+++ b/qroad/src/types/admin.ts
@@ -58,6 +58,7 @@ export interface PublicationDetailResponse {
 export interface ArticleSimple {
     id: number;
     title: string;
+    imagePath?: string;
 }
 
 export interface UserLandingPageResponse {
@@ -72,6 +73,7 @@ export interface RelatedArticle {
     title: string;
     content: string;
     link: string;
+    imagePath?: string;
 }
 
 export interface RelatedPolicy {


### PR DESCRIPTION
## 작업 목적
- 관리자 발행/제보 화면을 최신 API 스펙과 맞춤
- 사용자 기사 화면에서 S3 object key 기반 이미지 렌더링 지원
- 사용자 상세 진입 시 로딩/에러 UI 톤 통일

## 주요 변경사항

### 1) 관리자 발행 플로우 정합성
- 발행 생성 요청을 `content/filePath` 기반에서 `tempKey` 기반으로 변경
- 발행 흐름:
  1. `POST /api/admin/publications/upload-url` 로 업로드 URL 발급
  2. 발급된 `uploadUrl`로 S3 `PUT` 업로드
  3. `POST /api/admin/publications`에 `title`, `publishedDate`, `tempKey` 전송
- PDF 미선택/비-PDF 파일 검증 추가

### 2) 관리자 제보 목록 API 정합성
- `GET /api/admin/reports` 응답 스키마(`totalCount`, `id`, `createdAt` 등)와 화면 데이터 매핑 정리
- 제보 목록 컬럼 정리:
  - 상태 컬럼 제거
  - 제목/본문/제보자 연락처/접수일/상세보기로 구성

### 3) 사용자 기사 이미지 처리 개선
- `imagePath`를 **직접 렌더링 URL이 아닌 S3 object key**로 간주
- 공용 변환 유틸 추가:
  - `toRenderableImageUrl(imagePath)`
  - 규칙: `VITE_S3_PUBLIC_BASE_URL` 또는 `VITE_IMAGE_BASE_URL` + object key
- 적용 화면:
  - 사용자 랜딩(주요뉴스/기사목록 썸네일)
  - 기사 상세 내 관련기사 썸네일
- 이미지가 없을 때 placeholder(아이콘 + "이미지 없음") 노출

### 4) 사용자 상세 진입 UX
- 기사 상세 로딩/에러 화면을 사용자 페이지 톤(`#F9FAFB`, 파란 로딩 스피너, 카드형 에러 UI)으로 통일

## 변경 파일(핵심)
- `qroad/src/features/admin/pages/IssueCreate.tsx`
- `qroad/src/api/admin/publications.ts`
- `qroad/src/api/admin/reports.ts`
- `qroad/src/features/admin/pages/ReportList.tsx`
- `qroad/src/shared/utils/image.ts`
- `qroad/src/features/user/pages/qrlandingPage.tsx`
- `qroad/src/features/user/pages/ArticleDetailPage.tsx`
- `qroad/src/features/user/pages/ArticleDetailPageWrapper.tsx`
- `qroad/src/types/admin.ts`
- `qroad/.env.example`

## 확인 사항
- [x] `npm run build` 통과
- [x] 발행 플로우: upload-url -> S3 PUT -> tempKey 발행 요청
- [x] 제보 목록 API 응답 매핑 확인
- [x] 이미지 key -> URL 변환 로직 적용
- [x] 이미지 없음 placeholder 노출 확인

## 환경변수
- 이미지 렌더링을 위해 아래 중 하나 설정 필요
  - `VITE_S3_PUBLIC_BASE_URL`
  - `VITE_IMAGE_BASE_URL`
