### PR TITLE
feat: 관리자 목록 필터 개선 및 사용자 감정 연동 안정화

### DIFF
--- a/qroad/docs/admin-publications-list-api-spec.md
+++ b/qroad/docs/admin-publications-list-api-spec.md
@@ -1,0 +1,68 @@
+# Admin Publications List API Spec
+
+## Endpoint
+
+- `GET /api/admin/publications`
+
+## Purpose
+
+- Admin 기사 목록 조회
+- 발행월 필터(드롭다운)
+- 통합 검색(호수 문자열 + 기사 제목)
+- 페이징
+
+## Query Parameters
+
+- `page` (optional, number, default: `1`)
+- `limit` (optional, number, default: `10`)
+- `month` (optional, string, format: `YYYY-MM`)
+  - 예: `2026-03`
+  - 발행일 기준 월 필터
+- `q` (optional, string)
+  - 통합 검색 키워드
+  - 호수(예: `2026-03`) 또는 기사 제목 검색어
+
+## Request Example
+
+```http
+GET /api/admin/publications?page=1&limit=10&month=2026-03&q=청년
+```
+
+## Response Example
+
+```json
+{
+  "total_count": 24,
+  "papers": [
+    {
+      "id": 101,
+      "title": "청년 주거지원 예산 확대",
+      "body": "...",
+      "published_date": "2026-03-12",
+      "admin": "관리자"
+    }
+  ]
+}
+```
+
+## Filter Rules
+
+- `month` 미전달 시 전체 월 조회
+- `q` 미전달/공백 시 검색 미적용
+- `month` + `q` 동시 전달 시 AND 조건
+
+## Validation / Errors
+
+- `month` 형식이 `YYYY-MM`이 아니면 `400 Bad Request`
+
+```json
+{
+  "message": "month must be YYYY-MM"
+}
+```
+
+## Frontend Mapping
+
+- 월 드롭다운 선택값 -> `month`
+- 검색창 입력값 -> `q`
+- 필터/검색 변경 시 `page`는 1로 리셋

--- a/qroad/src/api/admin/publications.ts
+++ b/qroad/src/api/admin/publications.ts
@@ -2,6 +2,7 @@ import apiClient, { unwrapResponse } from '../client';
 import {
     CreatePublicationRequest,
     CreatePublicationResponse,
+    GetPublicationsParams,
     PublicationDetailResponse,
     PublicationListResponse,
     PublicationProgressResponse,
@@ -57,9 +58,16 @@ export const publicationsApi = {
         return unwrapResponse(res) as PublicationProgressResponse;
     },
 
-    getAll: async (params: { page?: number; limit?: number } = {}): Promise<PublicationListResponse> => {
-        const { page = 1, limit = 10 } = params;
-        const res = await apiClient.get('/api/admin/publications', { params: { page, limit } });
+    getAll: async (params: GetPublicationsParams = {}): Promise<PublicationListResponse> => {
+        const { page = 1, limit = 10, month, q } = params;
+        const res = await apiClient.get('/api/admin/publications', {
+            params: {
+                page,
+                limit,
+                ...(month ? { month } : {}),
+                ...(q ? { q } : {}),
+            },
+        });
         const body = unwrapResponse(res) as PublicationListResponse | undefined;
         return body ?? { total_count: 0, papers: [] };
     },

--- a/qroad/src/api/client.ts
+++ b/qroad/src/api/client.ts
@@ -2,7 +2,6 @@ import axios from 'axios';
 
 const apiClient = axios.create({
     baseURL: import.meta.env.VITE_API_BASE_URL,
-    timeout: 300000, // 5분 (300초)
     headers: {
         'Content-Type': 'application/json',
     },

--- a/qroad/src/api/user/index.ts
+++ b/qroad/src/api/user/index.ts
@@ -8,7 +8,7 @@ export const userApi = {
     },
 
     getArticleDetail: async (articleId: number): Promise<ArticleDetailResponse> => {
-        const res = await apiClient.get(`/api/articles/${articleId}`);
+        const res = await apiClient.get(`/api/articles/${articleId}`, { withCredentials: true });
         return unwrapResponse(res) as ArticleDetailResponse;
     },
 
@@ -18,7 +18,7 @@ export const userApi = {
     },
 
     toggleEmotion: async (articleId: number, payload: CreateEmotionRequest): Promise<CreateEmotionResponse> => {
-        const res = await apiClient.post(`/api/articles/${articleId}/emotions`, payload);
+        const res = await apiClient.post(`/api/articles/${articleId}/emotions`, payload, { withCredentials: true });
         return unwrapResponse(res) as CreateEmotionResponse;
     },
 };

--- a/qroad/src/features/admin/pages/IssueList.tsx
+++ b/qroad/src/features/admin/pages/IssueList.tsx
@@ -10,7 +10,6 @@ const ITEMS_PER_PAGE = 10;
 const categories = ['경제', '문화', '교통', '안전', '행사'];
 const getCategory = (id: number) => categories[id % categories.length];
 const getViews = (id: number) => (id * 123 + 456).toLocaleString();
-const getStatus = (id: number) => id % 3 === 0 ? '수정중' : '발행완료';
 const formatIssueNumber = (dateString: string) => {
     if (!dateString) return '2024-01';
     return dateString.substring(0, 7); // Extracts "2024-01" from "2024-01-15"
@@ -19,11 +18,23 @@ const formatPublishedDate = (dateString: string) => {
     if (!dateString) return '2024.01.15';
     return dateString.split('-').join('.');
 };
-
 export const IssueList = () => {
     const navigate = useNavigate();
     const [currentPage, setCurrentPage] = useState(1);
-    const { data, isLoading, error } = usePublications({ page: currentPage, limit: ITEMS_PER_PAGE });
+    const [selectedMonth, setSelectedMonth] = useState('');
+    const [searchInput, setSearchInput] = useState('');
+    const [searchKeyword, setSearchKeyword] = useState('');
+
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [selectedMonth, searchKeyword]);
+
+    const { data, isLoading, error } = usePublications({
+        page: currentPage,
+        limit: ITEMS_PER_PAGE,
+        month: selectedMonth || undefined,
+        q: searchKeyword || undefined,
+    });
 
     // 로그인 직후 환영 메시지 표시
     useEffect(() => {
@@ -100,33 +111,35 @@ export const IssueList = () => {
             <div className="mt-[54px] w-full flex items-center justify-between">
                 <div className="flex gap-[16px]">
                     <div className="relative">
-                        <select className="w-[141px] h-[37px] appearance-none bg-[#FFFFFF] border border-[#D1D5DB] rounded-[8px] pl-3 pr-8 font-normal text-[14px] leading-[17px] tracking-[-0.5px] text-[#000000] outline-none">
-                            <option>전체 호수</option>
-                        </select>
-                        <div className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none">
-                            <svg width="10" height="6" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M1 1L5 5L9 1" stroke="#000000" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                            </svg>
-                        </div>
+                        <input
+                            type="month"
+                            value={selectedMonth}
+                            onChange={(e) => setSelectedMonth(e.target.value)}
+                            className="w-[160px] h-[37px] bg-[#FFFFFF] border border-[#D1D5DB] rounded-[8px] px-3 font-normal text-[14px] leading-[17px] tracking-[-0.5px] text-[#000000] outline-none"
+                        />
                     </div>
-                    
-                    <div className="relative">
-                        <select className="w-[106px] h-[37px] appearance-none bg-[#FFFFFF] border border-[#D1D5DB] rounded-[8px] pl-3 pr-8 font-normal text-[14px] leading-[17px] tracking-[-0.5px] text-[#000000] outline-none">
-                            <option>전체 상태</option>
-                        </select>
-                        <div className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none">
-                            <svg width="10" height="6" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M1 1L5 5L9 1" stroke="#000000" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                            </svg>
-                        </div>
-                    </div>
+                    {selectedMonth && (
+                        <button
+                            type="button"
+                            onClick={() => setSelectedMonth('')}
+                            className="h-[37px] px-3 bg-[#FFFFFF] border border-[#D1D5DB] rounded-[8px] font-normal text-[14px] text-[#374151]"
+                        >
+                            전체
+                        </button>
+                    )}
                 </div>
 
                 <div className="relative">
                     <input 
                         type="text" 
-                        placeholder="기사 제목 검색..." 
-                        className="w-[256px] h-[38px] bg-[#FFFFFF] border border-[#D1D5DB] rounded-[8px] pl-10 pr-4 font-normal text-[14px] leading-[20px] tracking-[-0.5px] placeholder:text-[rgba(0,0,0,0.5)] outline-none focus:border-[#3B82F6]"
+                        value={searchInput}
+                        onChange={(e) => setSearchInput(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
+                            setSearchKeyword(searchInput.trim());
+                        }}
+                        placeholder="호수(예: 2026-03) 또는 기사 제목 검색..." 
+                        className="w-[360px] h-[38px] bg-[#FFFFFF] border border-[#D1D5DB] rounded-[8px] pl-10 pr-4 font-normal text-[14px] leading-[20px] tracking-[-0.5px] placeholder:text-[rgba(0,0,0,0.5)] outline-none focus:border-[#3B82F6]"
                     />
                     <Search className="absolute left-[12px] top-[11px] w-4 h-4 text-[#9CA3AF]" />
                 </div>
@@ -142,14 +155,12 @@ export const IssueList = () => {
                             <th className="w-[156px] h-[48.5px] font-medium text-[12px] leading-[15px] tracking-[0.1px] text-[#6B7280] text-center font-['Inter']">카테고리</th>
                             <th className="w-[191px] h-[48.5px] font-medium text-[12px] leading-[15px] tracking-[0.1px] text-[#6B7280] text-center font-['Inter']">발행일</th>
                             <th className="w-[136px] h-[48.5px] font-medium text-[12px] leading-[15px] tracking-[0.1px] text-[#6B7280] text-center font-['Inter']">조회수</th>
-                            <th className="w-[177px] h-[48.5px] font-medium text-[12px] leading-[15px] tracking-[0.1px] text-[#6B7280] text-center font-['Inter']">상태</th>
                             <th className="w-[215px] h-[48.5px] font-medium text-[12px] leading-[15px] tracking-[0.1px] text-[#6B7280] text-center font-['Inter']">관리</th>
                         </tr>
                     </thead>
                     <tbody className="bg-[#FFFFFF]">
                         {publications.length > 0 ? (
                             publications.map((pub, idx) => {
-                                const status = getStatus(pub.id);
                                 return (
                                     <tr 
                                         key={pub.id} 
@@ -172,13 +183,6 @@ export const IssueList = () => {
                                             {getViews(pub.id)}
                                         </td>
                                         <td className="text-center">
-                                            <span className={`inline-flex items-center justify-center px-[10px] h-[24px] rounded-full font-semibold text-[12px] leading-[15px] tracking-[-0.5px] ${
-                                                status === '발행완료' ? 'bg-[#DCFCE7] text-[#166534]' : 'bg-[#FEF9C3] text-[#854D0E]'
-                                            }`}>
-                                                {status}
-                                            </span>
-                                        </td>
-                                        <td className="text-center">
                                             <button 
                                                 onClick={(e) => {
                                                     e.stopPropagation();
@@ -194,7 +198,7 @@ export const IssueList = () => {
                             })
                         ) : (
                             <tr>
-                                <td colSpan={7} className="text-center py-10 font-normal text-[14px] text-[#6B7280]">
+                                <td colSpan={6} className="text-center py-10 font-normal text-[14px] text-[#6B7280]">
                                     표시할 기사가 없습니다.
                                 </td>
                             </tr>

--- a/qroad/src/features/user/pages/ArticleDetailPage.tsx
+++ b/qroad/src/features/user/pages/ArticleDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { 
   ArrowLeft, Sparkles, Check, Building, User, ImageOff,
   Landmark, Home, Coins, ThumbsUp, Heart, Frown, Angry, MessageSquareWarning 
@@ -14,22 +14,32 @@ interface ArticleDetailProps {
 
 type EmotionState = Record<EmotionType, { isActive: boolean; count: number }>;
 
+const createEmotionState = (myEmotion: EmotionType | null): EmotionState => ({
+	LIKE: { isActive: myEmotion === "LIKE", count: 0 },
+	HEARTWARMING: { isActive: myEmotion === "HEARTWARMING", count: 0 },
+	SAD: { isActive: myEmotion === "SAD", count: 0 },
+	ANGRY: { isActive: myEmotion === "ANGRY", count: 0 },
+	WANT_FOLLOW_UP: { isActive: myEmotion === "WANT_FOLLOW_UP", count: 0 },
+});
+
 export function ArticleDetail({ article, onBack }: ArticleDetailProps) {
-	const [emotions, setEmotions] = useState<EmotionState>({
-		LIKE: { isActive: false, count: 0 },
-		HEARTWARMING: { isActive: false, count: 0 },
-		SAD: { isActive: false, count: 0 },
-		ANGRY: { isActive: false, count: 0 },
-		WANT_FOLLOW_UP: { isActive: false, count: 0 },
-	});
+	const [emotions, setEmotions] = useState<EmotionState>(() => createEmotionState(article.myEmotion ?? null));
+
+	useEffect(() => {
+		setEmotions(createEmotionState(article.myEmotion ?? null));
+	}, [article.myEmotion]);
 
 	const handleEmotionToggle = async (type: EmotionType) => {
 		try {
 			const res = await userApi.toggleEmotion(article.articleId, { emotionType: type });
-			setEmotions(prev => ({
-				...prev,
-				[type]: { isActive: res.isActive, count: res.totalCount }
-			}));
+			setEmotions((prev) => {
+				const next = { ...prev };
+				(Object.keys(next) as EmotionType[]).forEach((key) => {
+					next[key] = { ...next[key], isActive: false };
+				});
+				next[type] = { ...next[type], isActive: res.isActive, count: res.totalCount };
+				return next;
+			});
 		} catch (error) {
 			console.error("Failed to toggle emotion:", error);
 			alert("감정 표현을 반영하지 못했습니다.");

--- a/qroad/src/features/user/pages/ArticleDetailPage.tsx
+++ b/qroad/src/features/user/pages/ArticleDetailPage.tsx
@@ -22,8 +22,27 @@ const createEmotionState = (myEmotion: EmotionType | null): EmotionState => ({
 	WANT_FOLLOW_UP: { isActive: myEmotion === "WANT_FOLLOW_UP", count: 0 },
 });
 
+const formatRelativeTime = (publishedDate: string) => {
+	const published = new Date(publishedDate);
+	if (Number.isNaN(published.getTime())) return "";
+
+	const diffMs = Date.now() - published.getTime();
+	if (diffMs <= 0) return "방금 전";
+
+	const minute = 60 * 1000;
+	const hour = 60 * minute;
+	const day = 24 * hour;
+
+	if (diffMs < hour) return `${Math.max(1, Math.floor(diffMs / minute))}분 전`;
+	if (diffMs < day) return `${Math.floor(diffMs / hour)}시간 전`;
+	if (diffMs < day * 7) return `${Math.floor(diffMs / day)}일 전`;
+
+	return publishedDate.slice(0, 10).replace(/-/g, ".");
+};
+
 export function ArticleDetail({ article, onBack }: ArticleDetailProps) {
 	const [emotions, setEmotions] = useState<EmotionState>(() => createEmotionState(article.myEmotion ?? null));
+	const relativePublishedTime = formatRelativeTime(article.publishedDate);
 
 	useEffect(() => {
 		setEmotions(createEmotionState(article.myEmotion ?? null));
@@ -71,7 +90,11 @@ export function ArticleDetail({ article, onBack }: ArticleDetailProps) {
 					<section className="w-full px-4 pt-5 pb-8">
 						<div className="flex items-center gap-2 mb-3">
 							<span className="text-[12px] font-normal text-[#2563EB] tracking-[-0.5px]">지역소식</span>
-							<span className="text-[12px] font-normal text-[#9CA3AF] tracking-[-0.5px]">5분 전</span>
+							{relativePublishedTime && (
+								<span className="text-[12px] font-normal text-[#9CA3AF] tracking-[-0.5px]">
+									{relativePublishedTime}
+								</span>
+							)}
 						</div>
 						
 						<h1 className="text-[24px] font-normal text-[#111827] leading-[30px] tracking-[-0.5px] mb-5">

--- a/qroad/src/hooks/admin/usePublications.ts
+++ b/qroad/src/hooks/admin/usePublications.ts
@@ -1,10 +1,10 @@
 ﻿import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { publicationsApi } from '@/api/admin/publications';
 import { toast } from 'sonner';
-import { CreatePublicationRequest } from '@/types/admin';
+import { CreatePublicationRequest, GetPublicationsParams } from '@/types/admin';
 
 // 신문 목록 조회 Hook
-export const usePublications = (params: { page?: number; limit?: number } = {}) => {
+export const usePublications = (params: GetPublicationsParams = {}) => {
     return useQuery({
         queryKey: ['publications', params],
         queryFn: () => publicationsApi.getAll(params),

--- a/qroad/src/types/admin.ts
+++ b/qroad/src/types/admin.ts
@@ -91,6 +91,7 @@ export interface ArticleDetailResponse {
     publishedDate: string;
     summary: string;
     keywords: string[];
+    myEmotion: EmotionType | null;
     articleRelatedDTOS: RelatedArticle[];
     policyArticleRelatedDTOS: RelatedPolicy[];
 }
@@ -107,6 +108,13 @@ export interface PublicationInList {
 export interface PublicationListResponse {
     total_count: number;
     papers: PublicationInList[];
+}
+
+export interface GetPublicationsParams {
+    page?: number;
+    limit?: number;
+    month?: string; // YYYY-MM
+    q?: string; // issue number or title keyword
 }
 
 // Report (이슈 제보) 관련


### PR DESCRIPTION
## 변경 사항
- 관리자 기사 목록
  - 상태 컬럼 제거
  - 월 필터를 `input type="month"`로 변경
  - 검색 동작을 자동(디바운스)에서 `Enter` 입력 시 실행으로 변경
  - 목록 API 파라미터 확장 (`month`, `q`)
- 사용자 기사 상세 감정
  - 상세 응답 `myEmotion` 기반 초기 active 상태 복원
  - 새로고침/재진입 시 감정 선택 상태 복원
  - 감정 토글 API 호출 시 쿠키 포함(`withCredentials`) 적용
- API 문서
  - 관리자 기사 목록 필터 API 명세 문서 추가

## 주요 파일
- `qroad/src/features/admin/pages/IssueList.tsx`
- `qroad/src/hooks/admin/usePublications.ts`
- `qroad/src/api/admin/publications.ts`
- `qroad/src/features/user/pages/ArticleDetailPage.tsx`
- `qroad/src/api/user/index.ts`
- `qroad/src/api/client.ts`
- `qroad/src/types/admin.ts`
- `qroad/docs/admin-publications-list-api-spec.md`

## 테스트
- `npm run build` 통과

## 확인 요청
- 백엔드에서 `GET /api/admin/publications`의 `month(YYYY-MM)`, `q` 파라미터 지원 여부
- 사용자 상세 `GET /api/articles/{id}`의 credentials 포함 요청 시 CORS 정책 확인