### PR TITLE
refactor(user/admin): 사용자 상세 연관 카드 단순화 및 관리자 이슈 목록 문구 정리

### DIFF
--- a/qroad/src/features/admin/pages/IssueList.tsx
+++ b/qroad/src/features/admin/pages/IssueList.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+﻿import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ChevronLeft, ChevronRight, Search, Loader2 } from 'lucide-react';
 import { usePublications } from '@/hooks/admin/usePublications';
@@ -6,18 +6,16 @@ import { toast } from 'sonner';
 
 const ITEMS_PER_PAGE = 10;
 
-// Mock data generation for missing fields
-const categories = ['경제', '문화', '교통', '안전', '행사'];
-const getCategory = (id: number) => categories[id % categories.length];
-const getViews = (id: number) => (id * 123 + 456).toLocaleString();
 const formatIssueNumber = (dateString: string) => {
     if (!dateString) return '2024-01';
     return dateString.substring(0, 7); // Extracts "2024-01" from "2024-01-15"
 };
+
 const formatPublishedDate = (dateString: string) => {
     if (!dateString) return '2024.01.15';
     return dateString.split('-').join('.');
 };
+
 export const IssueList = () => {
     const navigate = useNavigate();
     const [currentPage, setCurrentPage] = useState(1);
@@ -36,13 +34,12 @@ export const IssueList = () => {
         q: searchKeyword || undefined,
     });
 
-    // 로그인 직후 환영 메시지 표시
     useEffect(() => {
         const justLoggedIn = localStorage.getItem('justLoggedIn');
         const loginId = localStorage.getItem('loginId');
 
         if (justLoggedIn === 'true') {
-            toast.success(`${loginId || '관리자'}님, 로그인했습니다`);
+            toast.success(`${loginId || '관리자'}님, 로그인했습니다.`);
             localStorage.removeItem('justLoggedIn');
         }
     }, []);
@@ -75,6 +72,7 @@ export const IssueList = () => {
                 pages.push(totalPages);
             }
         }
+
         return pages;
     };
 
@@ -89,25 +87,22 @@ export const IssueList = () => {
     if (error) {
         return (
             <div className="flex items-center justify-center h-full w-full text-[#EF4444]">
-                기사 목록을 불러올 수 없습니다.
+                신문 목록을 불러올 수 없습니다.
             </div>
         );
     }
 
     return (
         <div className="w-full h-full bg-[#F9FAFB] p-8 font-['Inter'] relative">
-            
-            {/* Page Header */}
             <div>
                 <h1 className="font-semibold text-[24px] leading-[32px] tracking-[-0.5px] text-[#111827]">
-                    전체 기사 목록
+                    전체 신문 목록
                 </h1>
                 <p className="mt-[10px] font-normal text-[16px] leading-[24px] tracking-[-0.5px] text-[#4B5563]">
-                    기사를 클릭하여 상세 정보를 확인하고 수정할 수 있습니다
+                    신문을 클릭하여 상세 정보를 확인하고 수정할 수 있습니다
                 </p>
             </div>
 
-            {/* Toolbar */}
             <div className="mt-[54px] w-full flex items-center justify-between">
                 <div className="flex gap-[16px]">
                     <div className="relative">
@@ -130,31 +125,28 @@ export const IssueList = () => {
                 </div>
 
                 <div className="relative">
-                    <input 
-                        type="text" 
+                    <input
+                        type="text"
                         value={searchInput}
                         onChange={(e) => setSearchInput(e.target.value)}
                         onKeyDown={(e) => {
                             if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
                             setSearchKeyword(searchInput.trim());
                         }}
-                        placeholder="호수(예: 2026-03) 또는 기사 제목 검색..." 
+                        placeholder="호수(예: 2026-03) 또는 신문 제목 검색..."
                         className="w-[360px] h-[38px] bg-[#FFFFFF] border border-[#D1D5DB] rounded-[8px] pl-10 pr-4 font-normal text-[14px] leading-[20px] tracking-[-0.5px] placeholder:text-[rgba(0,0,0,0.5)] outline-none focus:border-[#3B82F6]"
                     />
                     <Search className="absolute left-[12px] top-[11px] w-4 h-4 text-[#9CA3AF]" />
                 </div>
             </div>
 
-            {/* Table Area */}
             <div className="mt-6 w-full bg-[#FFFFFF] border border-[#E5E7EB] shadow-[0px_1px_2px_rgba(0,0,0,0.05)] rounded-[8px] overflow-hidden">
                 <table className="w-full text-left border-collapse">
                     <thead className="bg-[#F9FAFB] border-b border-[#E5E7EB]">
                         <tr>
-                            <th className="w-[165px] h-[48.5px] font-medium text-[12px] leading-[15px] tracking-[0.1px] text-[#6B7280] text-center font-['Inter']">호수</th>
-                            <th className="w-[491px] h-[48.5px] font-medium text-[12px] leading-[15px] tracking-[0.1px] text-[#6B7280] text-center font-['Inter']">제목</th>
-                            <th className="w-[156px] h-[48.5px] font-medium text-[12px] leading-[15px] tracking-[0.1px] text-[#6B7280] text-center font-['Inter']">카테고리</th>
-                            <th className="w-[191px] h-[48.5px] font-medium text-[12px] leading-[15px] tracking-[0.1px] text-[#6B7280] text-center font-['Inter']">발행일</th>
-                            <th className="w-[136px] h-[48.5px] font-medium text-[12px] leading-[15px] tracking-[0.1px] text-[#6B7280] text-center font-['Inter']">조회수</th>
+                            <th className="w-[180px] h-[48.5px] font-medium text-[12px] leading-[15px] tracking-[0.1px] text-[#6B7280] text-center font-['Inter']">호수</th>
+                            <th className="h-[48.5px] font-medium text-[12px] leading-[15px] tracking-[0.1px] text-[#6B7280] text-center font-['Inter']">제목</th>
+                            <th className="w-[220px] h-[48.5px] font-medium text-[12px] leading-[15px] tracking-[0.1px] text-[#6B7280] text-center font-['Inter']">발행일</th>
                             <th className="w-[215px] h-[48.5px] font-medium text-[12px] leading-[15px] tracking-[0.1px] text-[#6B7280] text-center font-['Inter']">관리</th>
                         </tr>
                     </thead>
@@ -162,8 +154,8 @@ export const IssueList = () => {
                         {publications.length > 0 ? (
                             publications.map((pub, idx) => {
                                 return (
-                                    <tr 
-                                        key={pub.id} 
+                                    <tr
+                                        key={pub.id}
                                         onClick={() => navigate(`/admin/issues/${pub.id}`)}
                                         className={`h-[69px] border-b border-[#E5E7EB] cursor-pointer hover:bg-[#F9FAFB] transition-colors ${idx === publications.length - 1 ? 'border-none' : ''}`}
                                     >
@@ -174,16 +166,10 @@ export const IssueList = () => {
                                             {pub.title}
                                         </td>
                                         <td className="text-center font-normal text-[14px] leading-[17px] tracking-[-0.5px] text-[#6B7280]">
-                                            {getCategory(pub.id)}
-                                        </td>
-                                        <td className="text-center font-normal text-[14px] leading-[17px] tracking-[-0.5px] text-[#6B7280]">
                                             {formatPublishedDate(pub.published_date)}
                                         </td>
-                                        <td className="text-center font-normal text-[14px] leading-[17px] tracking-[-0.5px] text-[#6B7280]">
-                                            {getViews(pub.id)}
-                                        </td>
                                         <td className="text-center">
-                                            <button 
+                                            <button
                                                 onClick={(e) => {
                                                     e.stopPropagation();
                                                     navigate(`/admin/issues/${pub.id}`);
@@ -198,8 +184,8 @@ export const IssueList = () => {
                             })
                         ) : (
                             <tr>
-                                <td colSpan={6} className="text-center py-10 font-normal text-[14px] text-[#6B7280]">
-                                    표시할 기사가 없습니다.
+                                <td colSpan={4} className="text-center py-10 font-normal text-[14px] text-[#6B7280]">
+                                    표시할 신문이 없습니다.
                                 </td>
                             </tr>
                         )}
@@ -207,24 +193,23 @@ export const IssueList = () => {
                 </table>
             </div>
 
-            {/* Pagination */}
             {publications.length > 0 && (
                 <div className="mt-[24px] w-full flex items-center justify-between">
                     <div className="flex items-center">
                         <span className="font-normal text-[14px] leading-[17px] tracking-[-0.5px] text-[#374151]">
-                            총 <span className="font-medium text-[14px] leading-[20px]">{data?.total_count || 0}</span> 개 기사 중 <span className="font-medium text-[14px] leading-[20px] tracking-[-0.7px]">{startIndex + 1}-{endIndex}</span> 개 표시
+                            총 <span className="font-medium text-[14px] leading-[20px]">{data?.total_count || 0}</span>개 신문 중 <span className="font-medium text-[14px] leading-[20px] tracking-[-0.7px]">{startIndex + 1}-{endIndex}</span>개 표시
                         </span>
                     </div>
 
                     <div className="flex items-center gap-[8px]">
-                        <button 
+                        <button
                             disabled={currentPage === 1}
-                            onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
+                            onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
                             className="w-[34.75px] h-[38px] bg-[#FFFFFF] border border-[#D1D5DB] rounded-[8px] flex items-center justify-center disabled:opacity-50 transition-colors"
                         >
                             <ChevronLeft className="w-4 h-4 text-[#6B7280]" />
                         </button>
-                        
+
                         {totalPages > 1 ? (
                             getPageNumbers().map((page, index) => (
                                 page === '...' ? (
@@ -234,8 +219,8 @@ export const IssueList = () => {
                                         key={page}
                                         onClick={() => setCurrentPage(page as number)}
                                         className={`min-w-[31.81px] h-[38px] px-[12px] border rounded-[8px] font-medium text-[14px] leading-[17px] tracking-[-0.5px] text-center transition-colors ${
-                                            currentPage === page 
-                                                ? 'bg-[#3B82F6] border-[#3B82F6] text-[#FFFFFF]' 
+                                            currentPage === page
+                                                ? 'bg-[#3B82F6] border-[#3B82F6] text-[#FFFFFF]'
                                                 : 'bg-[#FFFFFF] border-[#D1D5DB] text-[#374151] hover:bg-[#F9FAFB]'
                                         }`}
                                     >
@@ -249,9 +234,9 @@ export const IssueList = () => {
                             </button>
                         )}
 
-                        <button 
+                        <button
                             disabled={currentPage === totalPages || totalPages === 0}
-                            onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
+                            onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
                             className="w-[34.75px] h-[38px] bg-[#FFFFFF] border border-[#D1D5DB] rounded-[8px] flex items-center justify-center disabled:opacity-50 transition-colors"
                         >
                             <ChevronRight className="w-4 h-4 text-[#374151]" />
@@ -259,7 +244,6 @@ export const IssueList = () => {
                     </div>
                 </div>
             )}
-            
         </div>
     );
 };

--- a/qroad/src/features/user/pages/ArticleDetailPage.tsx
+++ b/qroad/src/features/user/pages/ArticleDetailPage.tsx
@@ -1,11 +1,10 @@
 import { useEffect, useState } from "react";
 import { 
   ArrowLeft, Sparkles, Check, Building, User,
-  Landmark, Home, Coins, ThumbsUp, Heart, Frown, Angry, MessageSquareWarning, Loader2
+  ThumbsUp, Heart, Frown, Angry, MessageSquareWarning, Loader2
 } from "lucide-react";
 import { ArticleDetailResponse, EmotionType, EmotionCounts } from '@/types/admin';
 import { userApi } from '@/api/user';
-import { ArticleImage } from '@/shared/components/ArticleImage';
 
 interface ArticleDetailProps {
 	article: ArticleDetailResponse;
@@ -195,26 +194,10 @@ export function ArticleDetail({ article, onBack }: ArticleDetailProps) {
 							</h2>
 							<div className="flex flex-col gap-3">
 								{article.policyArticleRelatedDTOS.map((policy, index) => {
-									const styles = [
-										{ bg: 'bg-[#EFF6FF]', border: 'border-[#E5E7EB]', iconBg: 'bg-[#EFF6FF]', iconColor: 'text-[#2563EB]', statusText: 'text-[#15803D]', status: '신청가능', agency: '서울시', Icon: Landmark },
-										{ bg: 'bg-white', border: 'border-[#E5E7EB]', iconBg: 'bg-[#FAF5FF]', iconColor: 'text-[#9333EA]', statusText: 'text-[#1D4ED8]', status: '진행중', agency: 'LH공사', Icon: Home },
-										{ bg: 'bg-white', border: 'border-[#E5E7EB]', iconBg: 'bg-[#FFF7ED]', iconColor: 'text-[#EA580C]', statusText: 'text-[#15803D]', status: '신청가능', agency: '주택도시기금', Icon: Coins },
-									];
-									const s = styles[index % 3];
-									
 									return (
-										<div key={policy.policyId ?? policy.id ?? `${policy.title}-${index}`} onClick={() => window.open(policy.link, '_blank')} className={`w-full p-4 ${s.bg} border ${s.border} rounded-[12px] flex items-start gap-4 cursor-pointer active:scale-[0.98] transition-transform`}>
-											<div className={`w-12 h-12 rounded-lg ${s.iconBg} flex items-center justify-center shrink-0`}>
-												<s.Icon className={`w-5 h-5 ${s.iconColor}`} />
-											</div>
-											<div className="flex flex-col justify-center flex-1">
-												<h3 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] mb-1 line-clamp-1">{policy.title}</h3>
-												<p className="text-[12px] font-normal text-[#4B5563] leading-[16px] tracking-[-0.5px] mb-2 line-clamp-1">{policy.content}</p>
-												<div className="flex items-center gap-2">
-													<span className={`text-[12px] font-normal ${s.statusText} tracking-[-0.5px]`}>{s.status}</span>
-													<span className="text-[12px] font-normal text-[#9CA3AF] tracking-[-0.5px]">{s.agency}</span>
-												</div>
-											</div>
+										<div key={policy.policyId ?? policy.id ?? `${policy.title}-${index}`} onClick={() => window.open(policy.link, '_blank')} className="w-full p-4 bg-white border border-[#E5E7EB] rounded-[12px] cursor-pointer active:scale-[0.98] transition-transform">
+											<h3 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] mb-1 line-clamp-1">{policy.title}</h3>
+											<p className="text-[12px] font-normal text-[#4B5563] leading-[16px] tracking-[-0.5px] line-clamp-2">{policy.content}</p>
 										</div>
 									);
 								})}
@@ -227,46 +210,19 @@ export function ArticleDetail({ article, onBack }: ArticleDetailProps) {
 								관련 정책
 							</h2>
 							<div className="flex flex-col gap-3">
-								<div className="w-full p-4 bg-white border border-[#E5E7EB] rounded-[12px] flex items-start gap-4 cursor-pointer active:scale-[0.98] transition-transform">
-									<div className="w-12 h-12 rounded-lg bg-[#EFF6FF] flex items-center justify-center shrink-0">
-										<Landmark className="w-5 h-5 text-[#2563EB]" />
-									</div>
-									<div className="flex flex-col justify-center flex-1">
-										<h3 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] mb-1 line-clamp-1">청년 월세 지원 사업</h3>
-										<p className="text-[12px] font-normal text-[#4B5563] leading-[16px] tracking-[-0.5px] mb-2 line-clamp-1">만 19-39세 청년에게 월 최대 30만원 지원</p>
-										<div className="flex items-center gap-2">
-											<span className="text-[12px] font-normal text-[#15803D] tracking-[-0.5px]">신청가능</span>
-											<span className="text-[12px] font-normal text-[#9CA3AF] tracking-[-0.5px]">서울시</span>
-										</div>
-									</div>
+								<div className="w-full p-4 bg-white border border-[#E5E7EB] rounded-[12px] cursor-pointer active:scale-[0.98] transition-transform">
+									<h3 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] mb-1 line-clamp-1">청년 월세 지원 사업</h3>
+									<p className="text-[12px] font-normal text-[#4B5563] leading-[16px] tracking-[-0.5px] line-clamp-2">만 19-39세 청년에게 월 최대 30만원 지원</p>
 								</div>
 								
-								<div className="w-full p-4 bg-white border border-[#E5E7EB] rounded-[12px] flex items-start gap-4 cursor-pointer active:scale-[0.98] transition-transform">
-									<div className="w-12 h-12 rounded-lg bg-[#FAF5FF] flex items-center justify-center shrink-0">
-										<Home className="w-5 h-5 text-[#9333EA]" />
-									</div>
-									<div className="flex flex-col justify-center flex-1">
-										<h3 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] mb-1 line-clamp-1">청년 임대주택 공급</h3>
-										<p className="text-[12px] font-normal text-[#4B5563] leading-[16px] tracking-[-0.5px] mb-2 line-clamp-1">시세 80% 이하 청년 전용 임대주택 공급</p>
-										<div className="flex items-center gap-2">
-											<span className="text-[12px] font-normal text-[#1D4ED8] tracking-[-0.5px]">진행중</span>
-											<span className="text-[12px] font-normal text-[#9CA3AF] tracking-[-0.5px]">LH공사</span>
-										</div>
-									</div>
+								<div className="w-full p-4 bg-white border border-[#E5E7EB] rounded-[12px] cursor-pointer active:scale-[0.98] transition-transform">
+									<h3 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] mb-1 line-clamp-1">청년 임대주택 공급</h3>
+									<p className="text-[12px] font-normal text-[#4B5563] leading-[16px] tracking-[-0.5px] line-clamp-2">시세 80% 이하 청년 전용 임대주택 공급</p>
 								</div>
 
-								<div className="w-full p-4 bg-white border border-[#E5E7EB] rounded-[12px] flex items-start gap-4 cursor-pointer active:scale-[0.98] transition-transform">
-									<div className="w-12 h-12 rounded-lg bg-[#FFF7ED] flex items-center justify-center shrink-0">
-										<Coins className="w-5 h-5 text-[#EA580C]" />
-									</div>
-									<div className="flex flex-col justify-center flex-1">
-										<h3 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] mb-1 line-clamp-1">청년 전월세 보증금 대출</h3>
-										<p className="text-[12px] font-normal text-[#4B5563] leading-[16px] tracking-[-0.5px] mb-2 line-clamp-1">최대 1억원, 연 1.5% 저금리 대출 지원</p>
-										<div className="flex items-center gap-2">
-											<span className="text-[12px] font-normal text-[#15803D] tracking-[-0.5px]">신청가능</span>
-											<span className="text-[12px] font-normal text-[#9CA3AF] tracking-[-0.5px]">주택도시기금</span>
-										</div>
-									</div>
+								<div className="w-full p-4 bg-white border border-[#E5E7EB] rounded-[12px] cursor-pointer active:scale-[0.98] transition-transform">
+									<h3 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] mb-1 line-clamp-1">청년 전월세 보증금 대출</h3>
+									<p className="text-[12px] font-normal text-[#4B5563] leading-[16px] tracking-[-0.5px] line-clamp-2">최대 1억원, 연 1.5% 저금리 대출 지원</p>
 								</div>
 							</div>
 						</section>
@@ -280,23 +236,13 @@ export function ArticleDetail({ article, onBack }: ArticleDetailProps) {
 							</h2>
 							<div className="flex flex-col gap-3">
 								{article.articleRelatedDTOS.map((related, index) => (
-									<div key={related.articleId ?? related.id ?? `${related.title}-${index}`} onClick={() => window.open(related.link, '_blank')} className="w-full p-[13px] bg-white border border-[#E5E7EB] rounded-[12px] flex gap-[12px] cursor-pointer active:scale-[0.98] transition-transform">
-										<ArticleImage
-											imageUrl={related.imageUrl}
-											imagePath={related.imagePath}
-											alt={related.title}
-											className="w-[80px] h-[80px] rounded-[8px] object-cover shrink-0"
-											fallbackClassName="w-[80px] h-[80px] rounded-[8px] bg-[#F3F4F6] shrink-0 overflow-hidden flex flex-col items-center justify-center text-[#9CA3AF]"
-											fallbackLabelClassName="text-[10px] tracking-[-0.5px]"
-										/>
-										<div className="flex flex-col justify-center flex-1">
-											<h3 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] mb-1 line-clamp-2">
-												{related.title}
-											</h3>
-											<p className="text-[12px] font-normal text-[#6B7280] leading-[16px] tracking-[-0.5px] mb-2 line-clamp-1">
-												{related.content}
-											</p>
-										</div>
+									<div key={related.articleId ?? related.id ?? `${related.title}-${index}`} onClick={() => window.open(related.link, '_blank')} className="w-full p-4 bg-white border border-[#E5E7EB] rounded-[12px] cursor-pointer active:scale-[0.98] transition-transform">
+										<h3 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] mb-1 line-clamp-2">
+											{related.title}
+										</h3>
+										<p className="text-[12px] font-normal text-[#6B7280] leading-[16px] tracking-[-0.5px] line-clamp-2">
+											{related.content}
+										</p>
 									</div>
 								))}
 							</div>
@@ -313,16 +259,13 @@ export function ArticleDetail({ article, onBack }: ArticleDetailProps) {
 									{ title: "지방 청년 주거 지원도 확대 추진", desc: "국토부, 전국 광역시 대상 정책 확산" },
 									{ title: "서울시 \"청년 정책 예산 전년比 25% 증액\"", desc: "2024년 청년 지원 예산 8천억원 편성" }
 								].map((mock, idx) => (
-									<div key={idx} className="w-full p-[13px] bg-white border border-[#E5E7EB] rounded-[12px] flex gap-[12px] cursor-pointer active:scale-[0.98] transition-transform">
-										<div className="w-[80px] h-[80px] rounded-[8px] bg-[#E5E7EB] shrink-0 overflow-hidden relative" />
-										<div className="flex flex-col justify-center flex-1">
-											<h3 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] mb-1 line-clamp-2">
-												{mock.title}
-											</h3>
-											<p className="text-[12px] font-normal text-[#6B7280] leading-[16px] tracking-[-0.5px] mb-2 line-clamp-1">
-												{mock.desc}
-											</p>
-										</div>
+									<div key={idx} className="w-full p-4 bg-white border border-[#E5E7EB] rounded-[12px] cursor-pointer active:scale-[0.98] transition-transform">
+										<h3 className="text-[14px] font-normal text-[#111827] leading-[20px] tracking-[-0.5px] mb-1 line-clamp-2">
+											{mock.title}
+										</h3>
+										<p className="text-[12px] font-normal text-[#6B7280] leading-[16px] tracking-[-0.5px] line-clamp-2">
+											{mock.desc}
+										</p>
 									</div>
 								))}
 							</div>


### PR DESCRIPTION
## 변경 내용
- 사용자 기사 상세 페이지에서 연관 영역 UI 단순화
  - 연관정책 카드의 아이콘/상태 스타일 로직 제거
  - 연관기사 카드의 이미지 렌더링 로직 제거
  - 목업 카드(연관정책/연관기사)도 텍스트 중심 카드로 통일
- 관리자 이슈 목록 문구/컬럼 정리
  - "기사" 중심 문구를 "신문" 기준으로 정리
  - 불필요 컬럼 제거 및 테이블/문구 정합성 수정

## 변경 파일
- `qroad/src/features/user/pages/ArticleDetailPage.tsx`
- `qroad/src/features/admin/pages/IssueList.tsx`

## 기대 효과
- 상세 페이지의 연관 카드 UI가 더 단순하고 일관되게 동작
- 이미지/아이콘 의존도를 줄여 표시 이슈 가능성 감소
- 관리자 목록 화면 용어 일관성 개선

## 체크리스트
- [ ] 사용자 기사 상세 진입 시 연관정책/연관기사 카드가 텍스트만 노출되는지 확인
- [ ] 연관 카드 클릭 시 외부 링크 이동 정상 동작 확인
- [ ] 관리자 이슈 목록의 문구/컬럼 표시 정상 확인
