### PR TITLE
chore: develop 브랜치 변경사항을 main에 반영 (PR #22 포함)

### DIFF
--- a/qroad/.env.example
+++ b/qroad/.env.example
@@ -1,10 +1,11 @@
-# Development (로컬 개발 시)
-# Vite 프록시를 사용하므로 상대 경로 사용
-VITE_API_BASE_URL=http://localhost:8080
+# 프론트엔드 API 기본 주소
+# - 비우면 상대 경로(/api)로 요청합니다.
+# - 전체 URL을 넣으면 해당 백엔드로 직접 요청합니다.
+VITE_API_BASE_URL=
 
-# Production (Vercel 배포 시)
-# Vercel 환경 변수에서 설정:
-# VITE_API_BASE_URL=
-# 
-# 참고: Vercel rewrites를 사용하므로 상대 경로(/api)로 요청하면
-# 자동으로 https://api.qroad.info/api로 프록시됩니다
+# 개발 서버 프록시 대상 (`vite dev`에서 /api 호출 시에만 사용)
+# 예시: http://localhost:8080
+VITE_DEV_PROXY_TARGET=http://localhost:8080
+
+# 선택: 정적 자산 기본 주소
+# VITE_S3_PUBLIC_BASE_URL=

--- a/qroad/.gitattributes
+++ b/qroad/.gitattributes
@@ -1,0 +1,20 @@
+# Normalize line endings for text files
+* text=auto eol=lf
+
+# Keep Windows scripts in CRLF when needed
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Common binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.woff binary
+*.woff2 binary
+*.ttf binary

--- a/qroad/DEPLOYMENT.md
+++ b/qroad/DEPLOYMENT.md
@@ -43,8 +43,8 @@ git push -u origin main
 - Install Command: `npm install`
 
 **Environment Variables**:
-```
-VITE_API_BASE_URL = (비워두기)
+```bash
+VITE_API_BASE_URL=https://YOUR_BACKEND_URL
 ```
 
 ### 2.3 도메인 설정
@@ -52,7 +52,7 @@ VITE_API_BASE_URL = (비워두기)
 1. **Settings → Domains**
 2. **Add Domain**: `qroad.info` 입력
 3. **Add** 클릭
-4. DNS 설정 확인 (이미 설정되어 있음)
+4. DNS 설정 확인
 
 ## 3. 자동 배포 설정
 
@@ -84,7 +84,6 @@ git push origin main
 
 - **Deployments** 탭에서 배포 상태 확인
 - **Logs** 탭에서 빌드 로그 확인
-- **Functions** 탭에서 Serverless Functions 확인 (있다면)
 
 ### 4.2 배포 URL
 
@@ -98,7 +97,7 @@ git push origin main
 1. **Settings → Environment Variables**
 2. **Add New**:
    - Name: `VITE_API_BASE_URL`
-   - Value: (비워두기)
+   - Value: `https://YOUR_BACKEND_URL`
    - Environment: Production, Preview, Development 모두 선택
 3. **Save**
 
@@ -124,16 +123,14 @@ git push origin main
 3. **환경 변수 확인**:
    - Settings → Environment Variables 확인
 
-### CORS 에러 시
+### API 연결 오류 시
 
-1. **vercel.json 확인**:
-   - rewrites 설정 확인
-   - 배포 후 적용되었는지 확인
+1. **환경 변수 확인**:
+   - `VITE_API_BASE_URL` 값이 올바른지 확인
 
-2. **백엔드 CORS 설정 확인**:
+2. **백엔드 헬스 체크**:
    ```bash
-   curl -I https://api.qroad.info/api/admin/login \
-     -H "Origin: https://qroad.info"
+   curl -I https://YOUR_BACKEND_URL/api/admin/login
    ```
 
 ## 7. Git 워크플로우
@@ -152,8 +149,6 @@ git commit -m "Add: new feature"
 git push origin feature/new-feature
 ```
 
-→ Vercel이 자동으로 프리뷰 배포 생성
-
 ### 7.2 프로덕션 배포
 
 ```bash
@@ -167,15 +162,13 @@ git merge feature/new-feature
 git push origin main
 ```
 
-→ Vercel이 자동으로 `qroad.info`에 배포
-
 ## 8. 체크리스트
 
 배포 전 확인:
 
 - [ ] GitHub 저장소 생성 및 코드 push
 - [ ] Vercel과 GitHub 저장소 연동
-- [ ] 환경 변수 설정 (`VITE_API_BASE_URL` 비워두기)
+- [ ] 환경 변수 설정 (`VITE_API_BASE_URL`)
 - [ ] 도메인 설정 (`qroad.info`)
 - [ ] 로컬 빌드 테스트 성공
 - [ ] main 브랜치에 push하여 배포

--- a/qroad/src/app/router.tsx
+++ b/qroad/src/app/router.tsx
@@ -1,16 +1,14 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom'
 
-// User Pages
+// 사용자 페이지
 import { QRLandingPage } from '@/features/user/pages/qrlandingPage'
 import { ArticleDetailWrapper } from '@/features/user/pages/ArticleDetailPageWrapper'
-import { ReportPage } from '@/features/user/pages/ReportPage'
 
-// Admin Pages
+// 관리자 페이지
 import { LoginPage } from '@/features/admin/pages/LoginPage'
 import { IssueList } from '@/features/admin/pages/IssueList'
 import { IssueCreate } from '@/features/admin/pages/IssueCreate'
 import { IssueEdit } from '@/features/admin/pages/IssueEdit'
-import { ReportList } from '@/features/admin/pages/ReportList'
 import { ProtectedRoute } from '@/features/admin/components/ProtectedRoute'
 import { AdminLayout } from '@/shared/components/Layout/AdminLayout'
 
@@ -19,7 +17,6 @@ export const router = createBrowserRouter([
     path: '/',
     element: <Navigate to="/admin/login" replace />,
   },
-  // 사용자 페이지
   {
     path: '/a/:paperId',
     element: <QRLandingPage />,
@@ -28,11 +25,6 @@ export const router = createBrowserRouter([
     path: '/article/:articleId',
     element: <ArticleDetailWrapper />,
   },
-  {
-    path: '/report',
-    element: <ReportPage />,
-  },
-  // 관리자 페이지
   {
     path: '/admin/login',
     element: <LoginPage />,
@@ -60,10 +52,6 @@ export const router = createBrowserRouter([
       {
         path: 'issues/:id',
         element: <IssueEdit />,
-      },
-      {
-        path: 'reports',
-        element: <ReportList />,
       },
     ],
   },

--- a/qroad/src/features/admin/pages/LoginPage.tsx
+++ b/qroad/src/features/admin/pages/LoginPage.tsx
@@ -106,7 +106,7 @@ export const LoginPage = () => {
                 {/* Footer Copy */}
                 <div className="mt-6 text-center">
                     <p className="font-normal text-[12px] leading-[16px] tracking-[-0.5px] text-[#6B7280]">
-                        © 2024 QRoad Admin. 모든 권리 보유.
+                        © 2026 QRoad Admin. 모든 권리 보유.
                     </p>
                 </div>
 

--- a/qroad/src/features/user/pages/qrlandingPage.tsx
+++ b/qroad/src/features/user/pages/qrlandingPage.tsx
@@ -12,8 +12,6 @@ interface ArticleListProps {
 }
 
 export function ArticleList({ onArticleClick, articles, isLoading, publishedDate }: ArticleListProps) {
-  const navigate = useNavigate();
-
   if (isLoading) {
     return (
       <div className="min-h-screen bg-[#F9FAFB] flex items-center justify-center">
@@ -37,23 +35,23 @@ export function ArticleList({ onArticleClick, articles, isLoading, publishedDate
             <BrandLogo className="h-[30px] sm:h-[34px] md:h-[38px] w-auto max-w-[145px] sm:max-w-[165px] md:max-w-[180px]" />
           </div>
           <a
-            href="https://curly-marjoram-9d4.notion.site/2bbe6f94cb6d806281d6cfe611061601"
+            href="https://www.okinews.com/com/kd.html"
             target="_blank"
             rel="noreferrer"
             className="bg-[#F3F4F6] rounded-full px-3 py-[6px] flex items-center justify-center hover:bg-gray-200 transition-colors"
           >
-            <span className="text-[12px] text-[#374151] tracking-[-0.5px]">신문 구독방법</span>
+            <span className="text-[12px] text-[#374151] tracking-[-0.5px]">옥천신문 구독 하기</span>
           </a>
         </header>
 
         <div className="w-full px-4 py-[16px] bg-gradient-to-r from-[#EFF6FF] to-[#EEF2FF] border-b border-[#DBEAFE] flex flex-col justify-center">
           <div className="flex flex-col gap-[2px] mb-[20px]">
             <h2 className="text-[16px] font-normal text-[#111827] tracking-[-0.5px]">오늘의 주간 소식</h2>
-            <p className="text-[12px] font-normal text-[#4B5563] tracking-[-0.5px]">발행일: {publishedDateLabel}</p>
+            <p className="text-[12px] font-normal text-[#4B5563] tracking-[-0.5px]">발행일 {publishedDateLabel}</p>
           </div>
           <div className="flex items-center gap-1.5">
             <img src="/robot.svg" alt="AI News" className="w-3.5 h-3.5" />
-            <span className="text-[14px] font-normal text-[#374151] tracking-[-0.5px]">AI가 선별한 오늘의 핵심 뉴스</span>
+            <span className="text-[14px] font-normal text-[#374151] tracking-[-0.5px]">AI가 정리한 오늘의 핵심 뉴스</span>
           </div>
         </div>
 
@@ -137,13 +135,13 @@ export function ArticleList({ onArticleClick, articles, isLoading, publishedDate
         <div className="fixed bottom-0 left-0 right-0 w-full bg-white flex flex-col items-center justify-center pt-3 pb-8 z-40 border-t border-[#E5E7EB]">
           <div className="w-full max-w-[375px] px-4 flex flex-col gap-[10px]">
             <button
-              onClick={() => navigate('/report')}
+              onClick={() => window.open('https://www.okinews.com/bbs/list.html?table=bbs_43', '_blank', 'noopener,noreferrer')}
               className="w-full h-[52px] bg-gradient-to-r from-[#2563EB] to-[#4F46E5] shadow-[0px_4px_6px_rgba(0,0,0,0.1),0px_10px_15px_rgba(0,0,0,0.1)] rounded-[12px] flex items-center justify-center gap-2 active:scale-[0.98] transition-transform"
             >
               <img src="/white_docu.svg" alt="Report" className="w-4 h-4 brightness-0 invert" />
               <span className="text-[16px] font-normal text-white text-center tracking-[-0.5px]">민원 및 제보</span>
             </button>
-            <p className="text-[12px] font-normal text-[#6B7280] text-center tracking-[-0.5px]">지역 소식을 편리하게 만나보세요.</p>
+            <p className="text-[12px] font-normal text-[#6B7280] text-center tracking-[-0.5px]">지역 소식을 빠르게 만나보세요</p>
           </div>
         </div>
       </div>
@@ -187,5 +185,3 @@ export function QRLandingPage() {
     />
   );
 }
-
-

--- a/qroad/src/shared/components/Layout/AdminLayout.tsx
+++ b/qroad/src/shared/components/Layout/AdminLayout.tsx
@@ -1,4 +1,4 @@
-import { History, PlusCircle, MessageCircle, ChevronDown, User as UserIcon } from 'lucide-react';
+import { History, PlusCircle, ChevronDown, User as UserIcon } from 'lucide-react';
 import { useLogout } from '@/hooks/admin/useAuth';
 import { useNavigate, useLocation, Outlet } from 'react-router-dom';
 import { BrandLogo } from '@/shared/components/BrandLogo';
@@ -19,27 +19,20 @@ export const AdminLayout = () => {
       icon: History,
       label: '발행 이력',
       path: '/admin/issues',
-      description: '발행된 모든 신문 관리'
+      description: '발행한 모든 신문 관리',
     },
     {
       icon: PlusCircle,
       label: 'QR 발행',
       path: '/admin/issues/create',
-      description: '새로운 QR 발행'
+      description: '새로운 QR 발행',
     },
-    {
-      icon: MessageCircle,
-      label: '제보 확인',
-      path: '/admin/reports', // Assume reports path, if not exists, user can update later
-      description: '구독자 제보 내용 확인'
-    }
   ];
 
   const isActive = (path: string) => location.pathname === path;
 
   return (
     <div className="min-h-screen bg-[#F9FAFB] flex flex-col font-['Inter'] relative w-full overflow-hidden">
-      
       {/* Header */}
       <header className="absolute w-full h-[65px] left-0 top-0 bg-[#FFFFFF] border-b border-[#E5E7EB] z-50">
         <div className="flex items-center justify-between h-full px-6">
@@ -47,7 +40,7 @@ export const AdminLayout = () => {
           <div
             className="flex items-center cursor-pointer"
             onClick={() => navigate('/admin/issues')}
-            title="홈으로 이동"
+            title="이슈로 이동"
           >
             <BrandLogo className="h-[30px] sm:h-[34px] lg:h-[40px] w-auto max-w-[170px] sm:max-w-[190px] lg:max-w-[220px]" alt="QRoad Admin Logo" />
           </div>
@@ -67,11 +60,9 @@ export const AdminLayout = () => {
 
       {/* Body Area */}
       <div className="absolute w-full top-[65px] bottom-0 flex">
-        
         {/* Sidebar Nav */}
         <nav className="w-[320px] h-full bg-[#FFFFFF] flex-shrink-0">
           <div className="w-[271px] ml-[24px] mt-[24px] flex flex-col gap-2">
-            
             {menuItems.map((item) => {
               const Icon = item.icon;
               const active = isActive(item.path);
@@ -104,7 +95,6 @@ export const AdminLayout = () => {
                 </div>
               );
             })}
-            
           </div>
         </nav>
 
@@ -113,7 +103,6 @@ export const AdminLayout = () => {
           <Outlet />
         </main>
       </div>
-
     </div>
   );
 };

--- a/qroad/vercel.json
+++ b/qroad/vercel.json
@@ -4,35 +4,8 @@
   "framework": "vite",
   "rewrites": [
     {
-      "source": "/api/:path*",
-      "destination": "https://api.qroad.info/api/:path*"
-    },
-    {
       "source": "/(.*)",
       "destination": "/index.html"
-    }
-  ],
-  "headers": [
-    {
-      "source": "/api/(.*)",
-      "headers": [
-        {
-          "key": "Access-Control-Allow-Credentials",
-          "value": "true"
-        },
-        {
-          "key": "Access-Control-Allow-Origin",
-          "value": "https://qroad.info"
-        },
-        {
-          "key": "Access-Control-Allow-Methods",
-          "value": "GET,OPTIONS,PATCH,DELETE,POST,PUT"
-        },
-        {
-          "key": "Access-Control-Allow-Headers",
-          "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization"
-        }
-      ]
     }
   ]
 }

--- a/qroad/vite.config.ts
+++ b/qroad/vite.config.ts
@@ -1,70 +1,75 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+export default defineConfig(({ mode }) => {
+  // .env ���Ͽ��� ȯ�溯���� �о�ɴϴ�.
+  const env = loadEnv(mode, process.cwd(), '')
+  // ���� ���� ���Ͻ� ���: ���� ���� �� -> API �⺻�� -> ���� �⺻�� ������ ���
+  const devProxyTarget = env.VITE_DEV_PROXY_TARGET || env.VITE_API_BASE_URL || 'http://localhost:8080'
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks: (id) => {
-          // React 관련 라이브러리를 별도 청크로 분리
-          if (id.includes('node_modules')) {
-            if (id.includes('react') || id.includes('react-dom') || id.includes('react-router-dom')) {
-              return 'react-vendor';
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: (id) => {
+            // ���̺귯������ ûũ�� �и��� �ʱ� �ε� ȿ���� ���Դϴ�.
+            if (id.includes('node_modules')) {
+              // React ���� ���̺귯��
+              if (id.includes('react') || id.includes('react-dom') || id.includes('react-router-dom')) {
+                return 'react-vendor'
+              }
+              // UI ���̺귯��
+              if (id.includes('@radix-ui')) {
+                return 'ui-vendor'
+              }
+              // �ִϸ��̼� ���̺귯��
+              if (id.includes('motion')) {
+                return 'animation-vendor'
+              }
+              // ������ ���̺귯��
+              if (id.includes('lucide-react')) {
+                return 'icon-vendor'
+              }
             }
-            // UI 라이브러리를 별도 청크로 분리
-            if (id.includes('@radix-ui')) {
-              return 'ui-vendor';
-            }
-            // 애니메이션 라이브러리
-            if (id.includes('motion')) {
-              return 'animation-vendor';
-            }
-            // 아이콘 라이브러리
-            if (id.includes('lucide-react')) {
-              return 'icon-vendor';
-            }
-          }
+          },
+        },
+      },
+      chunkSizeWarningLimit: 600,
+    },
+    server: {
+      port: 3000,
+      proxy: {
+        '/api': {
+          target: devProxyTarget,
+          changeOrigin: true,
+          secure: false,
+          timeout: 60000,
+          proxyTimeout: 60000,
+          cookieDomainRewrite: 'localhost',
+          configure: (proxy) => {
+            proxy.on('error', (err) => {
+              console.log('proxy error', err)
+            })
+            proxy.on('proxyReq', (proxyReq, req) => {
+              console.log('Sending Request to the Target:', req.method, req.url)
+              // ���� Content-Type ����� �����մϴ�.
+              if (req.headers['content-type']) {
+                proxyReq.setHeader('Content-Type', req.headers['content-type'])
+              }
+            })
+            proxy.on('proxyRes', (proxyRes, req) => {
+              console.log('Received Response from the Target:', proxyRes.statusCode, req.url)
+            })
+          },
         },
       },
     },
-    chunkSizeWarningLimit: 600,
-  },
-  server: {
-    port: 3000,
-    proxy: {
-      '/api': {
-        target: 'https://api.qroad.info',
-        changeOrigin: true,
-        secure: false,
-        timeout: 60000,
-        proxyTimeout: 60000,
-        cookieDomainRewrite: 'localhost',
-        headers: {
-          'Origin': 'https://api.qroad.info',
-        },
-        configure: (proxy, _options) => {
-          proxy.on('error', (err, _req, _res) => {
-            console.log('proxy error', err);
-          });
-          proxy.on('proxyReq', (proxyReq, req, _res) => {
-            console.log('Sending Request to the Target:', req.method, req.url);
-            // 원본 헤더 유지
-            if (req.headers['content-type']) {
-              proxyReq.setHeader('Content-Type', req.headers['content-type']);
-            }
-          });
-          proxy.on('proxyRes', (proxyRes, req, _res) => {
-            console.log('Received Response from the Target:', proxyRes.statusCode, req.url);
-          });
-        },
-      },
-    },
-  },
+  }
 })


### PR DESCRIPTION
## 머지 대상
- from: `develop`
- to: `main`

## 포함 커밋
- `7f920c1` fix: 한글 깨짐 및 환경변수 기반 설정 정리
- `a79104c` chore: 관리자 로그인 푸터 연도 문구 수정
- `40d5a7e` Merge pull request #22 from `fix/korean-encoding-and-config`

## 주요 반영 내용
### 1) 링크 변경 (중요)
- `qroad/src/features/user/pages/qrlandingPage.tsx`
- 구독 링크 변경  
  - 기존: `https://curly-marjoram-9d4.notion.site/2bbe6f94cb6d806281d6cfe611061601`
  - 변경: `https://www.okinews.com/com/kd.html`
- 민원/제보 버튼 동작 변경  
  - 기존: 내부 라우팅 `/report`
  - 변경: 외부 링크 오픈 `https://www.okinews.com/bbs/list.html?table=bbs_43` (새 탭)

### 2) 라우트/관리자 메뉴 정리
- `qroad/src/app/router.tsx`
  - `/report` 제거
  - `/admin/reports` 제거
- `qroad/src/shared/components/Layout/AdminLayout.tsx`
  - 사이드바 `제보 확인` 메뉴 제거

### 3) 환경변수/배포 설정 정리
- `qroad/.env.example`
  - `VITE_API_BASE_URL` 정리
  - `VITE_DEV_PROXY_TARGET` 추가
- `qroad/vite.config.ts`
  - `loadEnv` 기반 프록시 타겟 동적 설정
- `qroad/vercel.json`
  - API rewrite/header 제거, SPA rewrite 중심 정리
- `qroad/DEPLOYMENT.md`
  - 배포 가이드 최신화
- `qroad/.gitattributes`
  - line ending/바이너리 규칙 추가

### 4) 기타
- `qroad/src/features/admin/pages/LoginPage.tsx`
  - 푸터 연도 `2024 -> 2026`

## 변경 파일
- `qroad/.env.example`
- `qroad/.gitattributes`
- `qroad/DEPLOYMENT.md`
- `qroad/src/app/router.tsx`
- `qroad/src/features/admin/pages/LoginPage.tsx`
- `qroad/src/features/user/pages/qrlandingPage.tsx`
- `qroad/src/shared/components/Layout/AdminLayout.tsx`
- `qroad/vercel.json`
- `qroad/vite.config.ts`

## 확인 체크리스트
- [ ] 구독 링크가 `https://www.okinews.com/com/kd.html`로 이동하는지
- [ ] 민원/제보 버튼이 `https://www.okinews.com/bbs/list.html?table=bbs_43` 새 탭으로 열리는지
- [ ] `/report`, `/admin/reports` 제거에 따른 영향 없는지
- [ ] 운영 환경변수(`VITE_API_BASE_URL`)가 올바르게 설정되어 있는지
- [ ] 관리자 로그인 푸터 연도 `2026` 반영 여부
